### PR TITLE
fix: ウィンドウ閉じ時の処理を修正

### DIFF
--- a/Sources/NiriMac/Bridge/AXObserverBridge.swift
+++ b/Sources/NiriMac/Bridge/AXObserverBridge.swift
@@ -14,6 +14,11 @@ final class AXObserverBridge {
     private var notificationCenter = NotificationCenter.default
     private var workspaceObservers: [Any] = []
 
+    /// AXUIElement のハッシュ値 → WindowID マッピング
+    /// kAXUIElementDestroyedNotification 発火時は要素が破棄済みのため
+    /// _AXUIElementGetWindow が失敗する。登録時に事前保存して対応する。
+    private var elementWindowMap: [CFHashCode: WindowID] = [:]
+
     func startObserving() {
         // 既存アプリを登録
         for app in NSWorkspace.shared.runningApplications where app.activationPolicy == .regular {
@@ -51,6 +56,7 @@ final class AXObserverBridge {
         }
         workspaceObservers.removeAll()
         observers.removeAll()
+        elementWindowMap.removeAll()
     }
 
     private func registerObserver(for pid: pid_t) {
@@ -63,19 +69,46 @@ final class AXObserverBridge {
         let appElement = AXUIElementCreateApplication(pid)
         let selfPtr = Unmanaged.passRetained(self).toOpaque()
 
-        let notifications: [String] = [
+        // アプリ要素レベルで登録する通知（kAXUIElementDestroyedNotification も含む）
+        let appNotifications: [String] = [
             kAXWindowCreatedNotification as String,
             kAXUIElementDestroyedNotification as String,
             kAXWindowMovedNotification as String,
             kAXWindowResizedNotification as String,
         ]
-
-        for notification in notifications {
+        for notification in appNotifications {
             AXObserverAddNotification(obs, appElement, notification as CFString, selfPtr)
+        }
+
+        // 既存ウィンドウにも個別登録（windowID の事前マッピングを兼ねる）
+        var windowList: CFTypeRef?
+        if AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &windowList) == .success,
+           let windows = windowList as? [AXUIElement] {
+            for windowElement in windows {
+                addDestroyedNotification(obs: obs, windowElement: windowElement, selfPtr: selfPtr)
+            }
         }
 
         CFRunLoopAddSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(obs), .defaultMode)
         observers[pid] = obs
+    }
+
+    /// 新規ウィンドウの破棄通知をウィンドウ要素に登録する（handleWindowCreated から呼ぶ）
+    func registerWindowDestroyedNotification(for windowElement: AXUIElement, pid: pid_t) {
+        guard let obs = observers[pid] else { return }
+        let selfPtr = Unmanaged.passRetained(self).toOpaque()
+        addDestroyedNotification(obs: obs, windowElement: windowElement, selfPtr: selfPtr)
+    }
+
+    /// 破棄通知の登録と elementWindowMap への事前保存を行う
+    private func addDestroyedNotification(obs: AXObserver, windowElement: AXUIElement, selfPtr: UnsafeMutableRawPointer) {
+        // 事前にwindowIDを取得してマッピングに保存（可能な場合）
+        var windowID: CGWindowID = 0
+        if _AXUIElementGetWindow(windowElement, &windowID) == .success {
+            elementWindowMap[CFHash(windowElement)] = windowID
+        }
+        // windowID取得の成否に関わらず通知を登録する
+        AXObserverAddNotification(obs, windowElement, kAXUIElementDestroyedNotification as CFString, selfPtr)
     }
 
     private func removeObserver(for pid: pid_t) {
@@ -100,10 +133,20 @@ final class AXObserverBridge {
             }
 
         case elementDestroyed:
-            var windowID: CGWindowID = 0
-            if _AXUIElementGetWindow(element, &windowID) == .success {
+            let hash = CFHash(element)
+            if let windowID = elementWindowMap[hash] {
+                // 事前保存したマッピングから取得（確実）
+                elementWindowMap.removeValue(forKey: hash)
                 DispatchQueue.main.async { [weak self] in
                     self?.onWindowDestroyed?(windowID)
+                }
+            } else {
+                // フォールバック: 要素から直接取得を試みる
+                var windowID: CGWindowID = 0
+                if _AXUIElementGetWindow(element, &windowID) == .success {
+                    DispatchQueue.main.async { [weak self] in
+                        self?.onWindowDestroyed?(windowID)
+                    }
                 }
             }
 

--- a/Sources/NiriMac/Core/Column.swift
+++ b/Sources/NiriMac/Core/Column.swift
@@ -31,10 +31,17 @@ struct Column {
 
     mutating func removeWindow(_ id: WindowID) {
         guard let idx = windows.firstIndex(of: id) else { return }
+        let wasActive = idx == activeWindowIndex
         windows.remove(at: idx)
-        if activeWindowIndex >= windows.count {
-            activeWindowIndex = max(0, windows.count - 1)
+        guard !windows.isEmpty else { return }
+        if wasActive {
+            // 右優先: 削除後の同インデックス（右隣）、末尾超えなら最後（左隣）
+            activeWindowIndex = min(idx, windows.count - 1)
+        } else if idx < activeWindowIndex {
+            // アクティブより前を削除 → インデックスをずらしてフォーカスを維持
+            activeWindowIndex -= 1
         }
+        // アクティブより後を削除 → 何もしない
     }
 
     mutating func focusNext() {

--- a/Sources/NiriMac/Core/Workspace.swift
+++ b/Sources/NiriMac/Core/Workspace.swift
@@ -107,8 +107,17 @@ struct Workspace {
         let screenLeft  = activeX + currentOffset
         let screenRight = screenLeft + activeWidth
 
-        // 2. 既に完全に収まっている → 何もしない
+        // 2. 既に完全に収まっている場合でも、コンテンツ縮小で右側に空白が生じていればクランプ
         if screenLeft >= 0 && screenRight <= effectiveWidth {
+            let lastX = xs.last! + nonPinnedCols.last!.width
+            let minOffset = min(0, effectiveWidth - gap * 2 - lastX)
+            if currentOffset < minOffset {
+                if animated {
+                    viewOffset.animateTo(minOffset)
+                } else {
+                    viewOffset = .static(offset: minOffset)
+                }
+            }
             return
         }
 
@@ -143,10 +152,20 @@ struct Workspace {
 
     mutating func removeColumn(at index: Int) {
         guard index < columns.count else { return }
+        let wasActive = index == activeColumnIndex
         columns.remove(at: index)
-        if activeColumnIndex >= columns.count {
-            activeColumnIndex = max(0, columns.count - 1)
+        guard !columns.isEmpty else {
+            activeColumnIndex = 0
+            return
         }
+        if wasActive {
+            // 右優先: 削除後の同インデックス（右隣）、末尾超えなら最後（左隣）
+            activeColumnIndex = min(index, columns.count - 1)
+        } else if index < activeColumnIndex {
+            // アクティブより前を削除 → インデックスをずらしてフォーカスを維持
+            activeColumnIndex -= 1
+        }
+        // アクティブより後を削除 → 何もしない
     }
 
     mutating func focusColumn(at index: Int) {

--- a/Sources/NiriMac/Orchestrator/WindowManager.swift
+++ b/Sources/NiriMac/Orchestrator/WindowManager.swift
@@ -345,6 +345,8 @@ final class WindowManager {
         // (既存ウィンドウの再検出を防ぐ)
         windowRegistry[window.id] = window
         axBridge.registerElement(window.axElement, for: window.id)
+        // ウィンドウ要素に破棄通知を個別登録（appElement への登録では発火しないため）
+        observer.registerWindowDestroyedNotification(for: window.axElement, pid: window.ownerPID)
 
         // screen.frame も Quartz 座標なのでそのまま比較
         guard !screens.isEmpty else { return }
@@ -373,20 +375,33 @@ final class WindowManager {
 
     private func handleWindowDestroyed(_ id: WindowID) {
         guard windowRegistry[id] != nil else { return }
+
+        // アクティブウィンドウかどうかを削除前に確認（②）
+        let screenIdx = activeScreenIndex()
+        let wasActive = screenIdx < screens.count &&
+            screens[screenIdx].activeWorkspace.activeWindowID == id
+
         windowRegistry.removeValue(forKey: id)
         axBridge.removeElement(for: id)
         parkedWindowIDs.remove(id)
 
+        // ドラッグ状態をクリア（③）
+        if mouseDownWindowID == id { mouseDownWindowID = nil }
+        if draggedWindowID == id { draggedWindowID = nil }
+
         for i in screens.indices {
             for j in screens[i].workspaces.indices {
                 screens[i].workspaces[j].removeWindow(id)
+                // カラム削除後に viewOffset を再センタリング（④）
+                screens[i].workspaces[j].recenterViewOffset(animated: true)
             }
         }
 
         applyLayout()
-        focusActiveWindow()
+        // アクティブウィンドウが閉じた場合のみフォーカスを移動（②）
+        if wasActive { focusActiveWindow() }
 
-        print("[niri-mac] Window destroyed: \(id)")
+        niriLog("[niri-mac] Window destroyed: \(id)")
     }
 
     private func handleApplicationTerminated(pid: pid_t) {

--- a/make-app.sh
+++ b/make-app.sh
@@ -4,10 +4,16 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
-echo "[niri-mac] Building..."
-swift build 2>&1
+CONFIG="${1:-release}"
+if [[ "$CONFIG" != "debug" && "$CONFIG" != "release" ]]; then
+    echo "Usage: $0 [debug|release]"
+    exit 1
+fi
 
-BINARY=".build/debug/NiriMac"
+echo "[niri-mac] Building ($CONFIG)..."
+swift build -c "$CONFIG" 2>&1
+
+BINARY=".build/$CONFIG/NiriMac"
 APP="NiriMac.app"
 CONTENTS="$APP/Contents"
 MACOS="$CONTENTS/MacOS"
@@ -18,7 +24,9 @@ mkdir -p "$MACOS"
 
 cp "$BINARY" "$MACOS/NiriMac"
 
-cat > "$CONTENTS/Info.plist" << 'EOF'
+BUILD_DATE=$(date '+%Y-%m-%d %H:%M:%S')
+
+cat > "$CONTENTS/Info.plist" << EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -37,6 +45,8 @@ cat > "$CONTENTS/Info.plist" << 'EOF'
     <string>APPL</string>
     <key>LSUIElement</key>
     <true/>
+    <key>BuildDate</key>
+    <string>${BUILD_DATE} (${CONFIG})</string>
     <key>NSAccessibilityUsageDescription</key>
     <string>NiriMac needs Accessibility access to manage window positions.</string>
     <key>NSInputMonitoringUsageDescription</key>


### PR DESCRIPTION
## Summary

- **AXObserverBridge**: `kAXUIElementDestroyedNotification` をウィンドウ要素に個別登録。破棄時に `_AXUIElementGetWindow` が失敗する問題を `elementWindowMap` で事前保存することで解決。アプリ要素レベルの登録も併用
- **Column/Workspace**: フォーカス移動を右優先に変更。非アクティブウィンドウを閉じた場合はフォーカスを維持
- **WindowManager**: ドラッグ状態のクリア、カラム削除後の `viewOffset` 再センタリング、アクティブウィンドウが閉じた場合のみフォーカスを移動
- **make-app.sh**: `debug`/`release` 引数対応、`BuildDate` を `Info.plist` に埋め込みビルド識別を容易化

## Test plan

- [ ] ウィンドウを閉じた時に空白が残らないことを確認
- [ ] アクティブウィンドウを閉じた時に右隣にフォーカスが移ることを確認
- [ ] 非アクティブウィンドウを閉じた時にフォーカスが変わらないことを確認
- [ ] `bash make-app.sh debug` / `bash make-app.sh release` が正常動作することを確認
- [ ] ログに `Window destroyed: <id>` が出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)