### PR TITLE
feat: Auto-Fit レイアウト（少数カラム時のセンタリング/2分割/3分割）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ AccessibilityBridge.setWindowFrame()  ← AX API で実際に移動
 
 **スクロールフォーカス移動クールダウン**: マウス/トラックパッドスクロールによるフォーカス移動は 0.3秒（`scrollFocusCooldown`）の cooldown で連打を防止する。
 
-**カラム幅サイクル**: `Ctrl+Opt+R` で 1/3 → 1/2 → 2/3 → 1.0（画面幅比率）をサイクル。
+**カラム幅サイクル**: `Ctrl+Opt+R` で 1/3 → 1/2 → 2/3（画面幅比率）をサイクル。
 
 ### 主要クラス・型
 
@@ -104,10 +104,11 @@ AccessibilityBridge.setWindowFrame()  ← AX API で実際に移動
 | Ctrl+Opt+Cmd+Shift | ↑ ↓ | アクティブウィンドウをワークスペース移動 |
 | Ctrl+Opt | Return | 左カラムに吸収（consumeIntoColumnLeft） |
 | Ctrl+Opt+Shift | Return | カラムから追い出し（expelFromColumn） |
-| Ctrl+Opt | R | カラム幅サイクル（1/3 → 1/2 → 2/3 → 1.0） |
+| Ctrl+Opt | R | カラム幅サイクル（1/3 → 1/2 → 2/3） |
 | Ctrl+Opt | P | Pin/Unpin カラム |
 | Ctrl+Opt+Shift | ↑ ↓ | カラム内ウィンドウ並び替え（上下） |
 | Ctrl+Opt | - / = | アクティブウィンドウの高さ縮小/拡大（±10%） |
+| Ctrl+Opt | A | Auto-Fit ON/OFF（メニューバーからも切替可） |
 | Ctrl+Opt | Q | 終了 |
 
 マウス操作: クリックでウィンドウフォーカス、水平スクロールでスクロール移動、ウィンドウをドラッグ（20px以上）でスワップ。

--- a/Sources/NiriMac/App/NiriMacApp.swift
+++ b/Sources/NiriMac/App/NiriMacApp.swift
@@ -9,6 +9,7 @@ final class NiriMacApp: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var pinnedTargetColumnIndex: Int?
     private var focusBorderMenuItem: NSMenuItem?
     private var focusDimMenuItem: NSMenuItem?
+    private var autoFitMenuItem: NSMenuItem?
     private var excludedAppsMenuItem: NSMenuItem?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -71,6 +72,11 @@ final class NiriMacApp: NSObject, NSApplicationDelegate, NSMenuDelegate {
         menu.addItem(excludedAppsItem)
         menu.addItem(NSMenuItem.separator())
 
+        let autoFitItem = NSMenuItem(title: "Auto-Fit Layout", action: #selector(toggleAutoFit), keyEquivalent: "")
+        autoFitItem.target = self
+        self.autoFitMenuItem = autoFitItem
+        menu.addItem(autoFitItem)
+
         let borderItem = NSMenuItem(title: "Focus Border", action: #selector(toggleFocusBorder), keyEquivalent: "")
         borderItem.target = self
         self.focusBorderMenuItem = borderItem
@@ -92,6 +98,7 @@ final class NiriMacApp: NSObject, NSApplicationDelegate, NSMenuDelegate {
         pinnedTargetColumnIndex = windowManager?.activeColumnIndex
         let isPinned = windowManager?.activeColumnIsPinned ?? false
         pinMenuItem?.title = isPinned ? "Unpin Column" : "Pin Column"
+        autoFitMenuItem?.state = windowManager?.autoFitEnabled == true ? .on : .off
         focusBorderMenuItem?.state = windowManager?.focusBorderEnabled == true ? .on : .off
         focusDimMenuItem?.state = windowManager?.focusDimEnabled == true ? .on : .off
 
@@ -131,6 +138,10 @@ final class NiriMacApp: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     @objc private func togglePin() {
         windowManager?.handleAction(.togglePin, forColumnIndex: pinnedTargetColumnIndex)
+    }
+
+    @objc private func toggleAutoFit() {
+        windowManager?.toggleAutoFit()
     }
 
     @objc private func toggleFocusBorder() {

--- a/Sources/NiriMac/Bridge/KeyboardShortcutManager.swift
+++ b/Sources/NiriMac/Bridge/KeyboardShortcutManager.swift
@@ -30,6 +30,7 @@ final class KeyboardShortcutManager {
         case togglePin
         case moveWindowUpInColumn, moveWindowDownInColumn
         case growWindowHeight, shrinkWindowHeight
+        case toggleAutoFit
         case quit
     }
 
@@ -83,6 +84,8 @@ final class KeyboardShortcutManager {
         // ウィンドウ高さリサイズ (Ctrl+Opt+- / Ctrl+Opt+=)
         Binding(modifiers: [.control, .option], keyCode: 27, action: .shrinkWindowHeight),
         Binding(modifiers: [.control, .option], keyCode: 24, action: .growWindowHeight),
+        // Auto-Fit ON/OFF (Ctrl+Opt+A)
+        Binding(modifiers: [.control, .option], keyCode: 0, action: .toggleAutoFit),
         // 終了
         Binding(modifiers: [.control, .option], keyCode: 12, action: .quit),
     ]

--- a/Sources/NiriMac/Core/Workspace.swift
+++ b/Sources/NiriMac/Core/Workspace.swift
@@ -8,6 +8,9 @@ struct Workspace {
     var activeColumnIndex: Int
     var viewOffset: ViewOffset
     var workingArea: CGRect
+    /// true のとき Auto-Fit を解除し通常スクロールにフォールバックする。
+    /// ユーザーが明示的にカラム幅を操作した時に立ち、カラム追加/削除でリセットされる。
+    var autoFitOverridden: Bool
 
     init(workingArea: CGRect) {
         self.id = UUID()
@@ -15,6 +18,17 @@ struct Workspace {
         self.activeColumnIndex = 0
         self.viewOffset = .static(offset: 0)
         self.workingArea = workingArea
+        self.autoFitOverridden = false
+    }
+
+    /// Auto-Fit レイアウトの適用可否（configの `autoFitEnabled` は呼び出し側で判定）。
+    /// - pinned カラムが無い
+    /// - カラム数が 1〜3
+    /// - ユーザーが手動でカラム幅を変更していない（`autoFitOverridden == false`）
+    var isAutoFitEligible: Bool {
+        guard !autoFitOverridden else { return false }
+        guard (1...3).contains(columns.count) else { return false }
+        return !columns.contains(where: { $0.isPinned })
     }
 
     var activeColumn: Column? {
@@ -144,16 +158,26 @@ struct Workspace {
     // MARK: - Column Operations
 
     mutating func addColumn(_ column: Column, at index: Int? = nil) {
+        let wasAboveThreshold = columns.count > 3
         let insertIndex = index ?? (activeColumnIndex + 1)
         let safeIndex = min(max(insertIndex, 0), columns.count)
         columns.insert(column, at: safeIndex)
         activeColumnIndex = safeIndex
+        // カラム数が Auto-Fit 閾値（3↔4）をまたいだ時だけ override をリセット。
+        // 1〜3 の範囲内での追加では手動設定を尊重する。
+        if wasAboveThreshold != (columns.count > 3) {
+            autoFitOverridden = false
+        }
     }
 
     mutating func removeColumn(at index: Int) {
         guard index < columns.count else { return }
         let wasActive = index == activeColumnIndex
+        let wasAboveThreshold = columns.count > 3
         columns.remove(at: index)
+        if wasAboveThreshold != (columns.count > 3) {
+            autoFitOverridden = false
+        }
         guard !columns.isEmpty else {
             activeColumnIndex = 0
             return

--- a/Sources/NiriMac/Engine/LayoutConfig.swift
+++ b/Sources/NiriMac/Engine/LayoutConfig.swift
@@ -51,4 +51,13 @@ struct LayoutConfig {
 
     /// タイリングから除外するアプリの bundleID セット
     var excludedBundleIDs: Set<String> = []
+
+    // MARK: - Auto-Fit
+
+    /// Auto-Fit レイアウトを有効にするか。
+    /// 非pinnedカラム数が 1〜3 のとき、スクロールせず画面を等分/中央配置する。
+    var autoFitEnabled: Bool = true
+
+    /// Auto-Fit で 1 カラム時のセンタリング幅（作業領域実効幅に対する比率）
+    var autoFitCenterWidthFraction: CGFloat = 2.0 / 3.0
 }

--- a/Sources/NiriMac/Engine/LayoutEngine.swift
+++ b/Sources/NiriMac/Engine/LayoutEngine.swift
@@ -58,6 +58,11 @@ enum LayoutEngine {
         let columns = workspace.columns
         guard !columns.isEmpty else { return results }
 
+        // Auto-Fit: 非pinnedカラム 1〜3 のときスクロール無しで画面を等分/中央配置
+        if config.autoFitEnabled && workspace.isAutoFitEligible {
+            return computeAutoFitFrames(workspace: workspace, config: config)
+        }
+
         let scrollOffset = workspace.viewOffset.current
         let workingArea = workspace.workingArea
         let gap = config.gapWidth
@@ -98,6 +103,73 @@ enum LayoutEngine {
                     x: screenX,
                     y: screenY,
                     width: column.width,
+                    height: winHeight
+                )
+                results.append((windowID, frame))
+            }
+        }
+
+        return results
+    }
+
+    /// Auto-Fit レイアウト: 非pinnedカラム 1〜3 のときスクロール無しで画面を等分/中央配置。
+    /// `workspace.isAutoFitEligible` が true の場合に呼ばれる前提。
+    /// - 1 カラム: `config.autoFitCenterWidthFraction` の幅で中央配置
+    /// - 2 カラム: 左右等分（`(effectiveWidth - gap) / 2`）
+    /// - 3 カラム: 3等分（`(effectiveWidth - 2*gap) / 3`）
+    /// viewOffset は無視される。Column.width は変更しない（復帰時に元幅へ戻る）。
+    static func computeAutoFitFrames(
+        workspace: Workspace,
+        config: LayoutConfig
+    ) -> [(WindowID, CGRect)] {
+        var results: [(WindowID, CGRect)] = []
+
+        let columns = workspace.columns
+        let n = columns.count
+        guard (1...3).contains(n) else { return results }
+
+        let workingArea = workspace.workingArea
+        let gap = config.gapWidth
+        // 両端ギャップを除いた実効幅
+        let effectiveWidth = workingArea.width - 2 * gap
+
+        // カラムごとの幅と左端X座標を決定
+        let colWidth: CGFloat
+        var xs: [CGFloat] = []
+        switch n {
+        case 1:
+            colWidth = effectiveWidth * config.autoFitCenterWidthFraction
+            xs = [workingArea.midX - colWidth / 2]
+        case 2:
+            colWidth = (effectiveWidth - gap) / 2
+            let leftX = workingArea.minX + gap
+            xs = [leftX, leftX + colWidth + gap]
+        case 3:
+            colWidth = (effectiveWidth - 2 * gap) / 3
+            let leftX = workingArea.minX + gap
+            xs = [
+                leftX,
+                leftX + colWidth + gap,
+                leftX + (colWidth + gap) * 2
+            ]
+        default:
+            return results
+        }
+
+        for (colIdx, column) in columns.enumerated() {
+            let heights = distributeColumnHeight(
+                column: column,
+                availableHeight: workingArea.height,
+                gap: config.gapHeight,
+                focusedIndex: column.activeWindowIndex
+            )
+            for (winIdx, windowID) in column.windows.enumerated() {
+                let (winY, winHeight) = heights[winIdx]
+                let screenY = workingArea.minY + winY
+                let frame = CGRect(
+                    x: xs[colIdx],
+                    y: screenY,
+                    width: colWidth,
                     height: winHeight
                 )
                 results.append((windowID, frame))

--- a/Sources/NiriMac/Orchestrator/WindowManager.swift
+++ b/Sources/NiriMac/Orchestrator/WindowManager.swift
@@ -694,6 +694,7 @@ final class WindowManager {
 
     var focusBorderEnabled: Bool { config.focusBorderEnabled }
     var focusDimEnabled: Bool { config.focusDimEnabled }
+    var autoFitEnabled: Bool { config.autoFitEnabled }
 
     func toggleFocusBorder() {
         config.focusBorderEnabled.toggle()
@@ -702,6 +703,12 @@ final class WindowManager {
 
     func toggleFocusDim() {
         config.focusDimEnabled.toggle()
+        needsLayout = true
+    }
+
+    func toggleAutoFit() {
+        config.autoFitEnabled.toggle()
+        niriLog("[action] toggleAutoFit → \(config.autoFitEnabled)")
         needsLayout = true
     }
 
@@ -797,11 +804,29 @@ final class WindowManager {
             expelWindowFromColumn(screenIdx: screenIdx)
 
         case .cycleColumnWidth:
-            let ws = screens[screenIdx].activeWorkspace
+            var ws = screens[screenIdx].activeWorkspace
             guard !ws.columns.isEmpty else { return }
             let activeIdx = ws.activeColumnIndex
             let screenWidth = screens[screenIdx].frame.width
-            let currentWidth = screens[screenIdx].activeWorkspace.columns[activeIdx].width
+
+            // Auto-Fit 中に cycle を押した場合、まず現在表示されている幅を全カラムに固定してから
+            // cycle を適用する。これをしないとアクティブ以外のカラムが stale な column.width に戻ってしまう。
+            if config.autoFitEnabled && ws.isAutoFitEligible {
+                let n = ws.columns.count
+                let effectiveWidth = ws.workingArea.width - 2 * config.gapWidth
+                let displayedWidth: CGFloat
+                switch n {
+                case 1: displayedWidth = effectiveWidth * config.autoFitCenterWidthFraction
+                case 2: displayedWidth = (effectiveWidth - config.gapWidth) / 2
+                case 3: displayedWidth = (effectiveWidth - 2 * config.gapWidth) / 3
+                default: displayedWidth = ws.columns[activeIdx].width
+                }
+                for i in 0..<ws.columns.count {
+                    ws.columns[i].width = displayedWidth
+                }
+            }
+
+            let currentWidth = ws.columns[activeIdx].width
             let currentFraction = currentWidth / screenWidth
             let nextPreset: CGFloat
             if currentFraction < 0.4 {
@@ -812,7 +837,12 @@ final class WindowManager {
                 nextPreset = 1.0/3.0
             }
             niriLog("[action] cycleColumnWidth col=\(activeIdx) \(Int(currentWidth))→\(Int(screenWidth * nextPreset))px")
-            screens[screenIdx].activeWorkspace.columns[activeIdx].width = screenWidth * nextPreset
+            ws.columns[activeIdx].width = screenWidth * nextPreset
+            // ユーザーが明示的に幅を操作したので Auto-Fit を解除
+            ws.autoFitOverridden = true
+            // Auto-Fit 中に裏で累積した viewOffset を破棄（stale スクロール防止）
+            ws.viewOffset = .static(offset: 0)
+            screens[screenIdx].activeWorkspace = ws
 
         case .togglePin:
             guard !screens[screenIdx].activeWorkspace.columns.isEmpty else { return }
@@ -840,6 +870,9 @@ final class WindowManager {
             niriLog("[action] shrinkWindowHeight")
             let colIdx = screens[screenIdx].activeWorkspace.activeColumnIndex
             screens[screenIdx].activeWorkspace.columns[colIdx].resizeActiveWindowHeight(delta: -0.10)
+
+        case .toggleAutoFit:
+            toggleAutoFit()
 
         case .quit:
             stop()
@@ -1223,6 +1256,12 @@ final class WindowManager {
 
         // Ctrl のみ + 水平スクロール → レイアウトスクロール
         guard filtered == [.control], abs(deltaX) > 0.5 else { return }
+
+        // Auto-Fit 中はスクロール自体が無意味なので viewOffset を触らない
+        // （触ると解除時に stale オフセットでレイアウトが飛ぶ）
+        if config.autoFitEnabled && screens[screenIdx].activeWorkspace.isAutoFitEligible {
+            return
+        }
 
         let sensitivity = isContinuous ? config.scrollSensitivity : config.mouseWheelScrollSensitivity
         let delta = deltaX * sensitivity

--- a/Tests/NiriMacTests/LayoutEngineTests.swift
+++ b/Tests/NiriMacTests/LayoutEngineTests.swift
@@ -64,6 +64,8 @@ struct LayoutEngineTests {
         ws.columns = [col]
         ws.activeColumnIndex = 0
         ws.viewOffset = .static(offset: 0)
+        // 通常スクロールパスを検証するため Auto-Fit を解除
+        ws.autoFitOverridden = true
 
         let config = LayoutConfig()
         let frames = LayoutEngine.computeWindowFrames(
@@ -78,6 +80,189 @@ struct LayoutEngineTests {
         // screenX = workingArea.minX + gapWidth + colX = 0 + 16 + 0 = 16
         #expect(abs(frame.origin.x - 16) < 0.001)
         #expect(abs(frame.width - 400) < 0.001)
+    }
+
+    // MARK: - Auto-Fit
+
+    @Test func autoFitCenter1Column() {
+        // 1 カラム: 2/3 幅で中央配置
+        var ws = Workspace(workingArea: CGRect(x: 0, y: 0, width: 1440, height: 900))
+        ws.columns = [Column(windows: [1], width: 400)]
+        ws.activeColumnIndex = 0
+
+        #expect(ws.isAutoFitEligible)
+
+        let config = LayoutConfig()
+        let frames = LayoutEngine.computeWindowFrames(
+            workspace: ws,
+            screenFrame: CGRect(x: 0, y: 0, width: 1440, height: 900),
+            config: config
+        )
+
+        #expect(frames.count == 1)
+        // effectiveWidth = 1440 - 32 = 1408, colWidth = 1408 * 2/3 ≈ 938.67
+        let expectedWidth: CGFloat = 1408.0 * (2.0 / 3.0)
+        let expectedX: CGFloat = 720 - expectedWidth / 2  // midX - width/2
+        #expect(abs(frames[0].1.width - expectedWidth) < 0.5)
+        #expect(abs(frames[0].1.origin.x - expectedX) < 0.5)
+    }
+
+    @Test func autoFitSplit2Columns() {
+        // 2 カラム: 左右等分
+        var ws = Workspace(workingArea: CGRect(x: 0, y: 0, width: 1440, height: 900))
+        ws.columns = [
+            Column(windows: [1], width: 400),
+            Column(windows: [2], width: 600),
+        ]
+        ws.activeColumnIndex = 0
+
+        let config = LayoutConfig()
+        let frames = LayoutEngine.computeWindowFrames(
+            workspace: ws,
+            screenFrame: CGRect(x: 0, y: 0, width: 1440, height: 900),
+            config: config
+        )
+
+        #expect(frames.count == 2)
+        // effectiveWidth = 1408, colWidth = (1408 - 16) / 2 = 696
+        let expectedWidth: CGFloat = (1408 - 16) / 2
+        #expect(abs(frames[0].1.width - expectedWidth) < 0.5)
+        #expect(abs(frames[1].1.width - expectedWidth) < 0.5)
+        #expect(abs(frames[0].1.origin.x - 16) < 0.5)  // minX + gap
+        #expect(abs(frames[1].1.origin.x - (16 + expectedWidth + 16)) < 0.5)
+    }
+
+    @Test func autoFitSplit3Columns() {
+        // 3 カラム: 3 等分
+        var ws = Workspace(workingArea: CGRect(x: 0, y: 0, width: 1440, height: 900))
+        ws.columns = [
+            Column(windows: [1], width: 400),
+            Column(windows: [2], width: 400),
+            Column(windows: [3], width: 400),
+        ]
+        ws.activeColumnIndex = 0
+
+        let config = LayoutConfig()
+        let frames = LayoutEngine.computeWindowFrames(
+            workspace: ws,
+            screenFrame: CGRect(x: 0, y: 0, width: 1440, height: 900),
+            config: config
+        )
+
+        #expect(frames.count == 3)
+        // effectiveWidth = 1408, colWidth = (1408 - 32) / 3 ≈ 458.67
+        let expectedWidth: CGFloat = (1408 - 32) / 3
+        for i in 0..<3 {
+            #expect(abs(frames[i].1.width - expectedWidth) < 0.5)
+        }
+        #expect(abs(frames[0].1.origin.x - 16) < 0.5)
+        #expect(abs(frames[1].1.origin.x - (16 + expectedWidth + 16)) < 0.5)
+        #expect(abs(frames[2].1.origin.x - (16 + (expectedWidth + 16) * 2)) < 0.5)
+    }
+
+    @Test func autoFitDisabledWhen4Columns() {
+        // 4 カラム: Auto-Fit 無効、通常スクロールに戻る
+        var ws = Workspace(workingArea: CGRect(x: 0, y: 0, width: 1440, height: 900))
+        ws.columns = [
+            Column(windows: [1], width: 400),
+            Column(windows: [2], width: 400),
+            Column(windows: [3], width: 400),
+            Column(windows: [4], width: 400),
+        ]
+        ws.activeColumnIndex = 0
+
+        #expect(!ws.isAutoFitEligible)
+    }
+
+    @Test func autoFitDisabledWithPinned() {
+        // pinned カラムがあれば Auto-Fit 無効
+        var ws = Workspace(workingArea: CGRect(x: 0, y: 0, width: 1440, height: 900))
+        var pinnedCol = Column(windows: [1], width: 400)
+        pinnedCol.isPinned = true
+        ws.columns = [
+            pinnedCol,
+            Column(windows: [2], width: 400),
+        ]
+        ws.activeColumnIndex = 1
+
+        #expect(!ws.isAutoFitEligible)
+    }
+
+    @Test func autoFitDisabledWhenOverridden() {
+        // autoFitOverridden が true のとき無効
+        var ws = Workspace(workingArea: CGRect(x: 0, y: 0, width: 1440, height: 900))
+        ws.columns = [Column(windows: [1], width: 400)]
+        ws.activeColumnIndex = 0
+        ws.autoFitOverridden = true
+
+        #expect(!ws.isAutoFitEligible)
+    }
+
+    @Test func autoFitOverridePreservedWithinThreshold() {
+        // 1〜3 の範囲内でのカラム追加では override は維持される（手動幅を尊重）
+        var ws = Workspace(workingArea: CGRect(x: 0, y: 0, width: 1440, height: 900))
+        ws.columns = [Column(windows: [1], width: 400)]
+        ws.activeColumnIndex = 0
+        ws.autoFitOverridden = true
+
+        ws.addColumn(Column(windows: [2], width: 400))
+        #expect(ws.columns.count == 2)
+        #expect(ws.autoFitOverridden == true)
+        #expect(!ws.isAutoFitEligible)
+    }
+
+    @Test func autoFitOverrideResetOnCrossingThresholdDown() {
+        // 4→3 で override リセットされ Auto-Fit 復帰
+        var ws = Workspace(workingArea: CGRect(x: 0, y: 0, width: 1440, height: 900))
+        ws.columns = [
+            Column(windows: [1], width: 400),
+            Column(windows: [2], width: 400),
+            Column(windows: [3], width: 400),
+            Column(windows: [4], width: 400),
+        ]
+        ws.activeColumnIndex = 0
+        ws.autoFitOverridden = true
+
+        ws.removeColumn(at: 3)
+        #expect(ws.columns.count == 3)
+        #expect(ws.autoFitOverridden == false)
+        #expect(ws.isAutoFitEligible)
+    }
+
+    @Test func autoFitOverrideResetOnCrossingThresholdUp() {
+        // 3→4 で override リセット（通常モードに移行するのでクリーンな状態に）
+        var ws = Workspace(workingArea: CGRect(x: 0, y: 0, width: 1440, height: 900))
+        ws.columns = [
+            Column(windows: [1], width: 400),
+            Column(windows: [2], width: 400),
+            Column(windows: [3], width: 400),
+        ]
+        ws.activeColumnIndex = 0
+        ws.autoFitOverridden = true
+
+        ws.addColumn(Column(windows: [4], width: 400))
+        #expect(ws.columns.count == 4)
+        #expect(ws.autoFitOverridden == false)
+        #expect(!ws.isAutoFitEligible)  // 4 カラムなので eligible には戻らない
+    }
+
+    @Test func autoFitDisabledByConfig() {
+        // config.autoFitEnabled = false で無効化
+        var ws = Workspace(workingArea: CGRect(x: 0, y: 0, width: 1440, height: 900))
+        ws.columns = [Column(windows: [1], width: 400)]
+        ws.activeColumnIndex = 0
+
+        var config = LayoutConfig()
+        config.autoFitEnabled = false
+        let frames = LayoutEngine.computeWindowFrames(
+            workspace: ws,
+            screenFrame: CGRect(x: 0, y: 0, width: 1440, height: 900),
+            config: config
+        )
+        // 通常パス: colWidth=400（入力のまま）、x = minX+gap+0 = 16
+        #expect(frames.count == 1)
+        #expect(abs(frames[0].1.width - 400) < 0.5)
+        #expect(abs(frames[0].1.origin.x - 16) < 0.5)
     }
 
     // MARK: - isWindowOffScreen (R-01)

--- a/Tests/NiriMacTests/TestTypes.swift
+++ b/Tests/NiriMacTests/TestTypes.swift
@@ -150,6 +150,7 @@ struct Workspace {
     var activeColumnIndex: Int
     var viewOffset: ViewOffset
     var workingArea: CGRect
+    var autoFitOverridden: Bool
 
     init(workingArea: CGRect) {
         self.id = UUID()
@@ -157,6 +158,13 @@ struct Workspace {
         self.activeColumnIndex = 0
         self.viewOffset = .static(offset: 0)
         self.workingArea = workingArea
+        self.autoFitOverridden = false
+    }
+
+    var isAutoFitEligible: Bool {
+        guard !autoFitOverridden else { return false }
+        guard (1...3).contains(columns.count) else { return false }
+        return !columns.contains(where: { $0.isPinned })
     }
 
     var activeColumn: Column? {
@@ -218,16 +226,24 @@ struct Workspace {
     // MARK: - Column Operations
 
     mutating func addColumn(_ column: Column, at index: Int? = nil) {
+        let wasAboveThreshold = columns.count > 3
         let insertIndex = index ?? (activeColumnIndex + 1)
         let safeIndex = min(max(insertIndex, 0), columns.count)
         columns.insert(column, at: safeIndex)
         activeColumnIndex = safeIndex
+        if wasAboveThreshold != (columns.count > 3) {
+            autoFitOverridden = false
+        }
     }
 
     mutating func removeColumn(at index: Int) {
         guard index < columns.count else { return }
         let wasActive = index == activeColumnIndex
+        let wasAboveThreshold = columns.count > 3
         columns.remove(at: index)
+        if wasAboveThreshold != (columns.count > 3) {
+            autoFitOverridden = false
+        }
         guard !columns.isEmpty else {
             activeColumnIndex = 0
             return
@@ -305,6 +321,8 @@ struct LayoutConfig {
     var gapHeight: CGFloat = 16
     var defaultColumnWidthFraction: CGFloat = 1.0 / 3.0
     var animationDuration: CFTimeInterval = 0.25
+    var autoFitEnabled: Bool = true
+    var autoFitCenterWidthFraction: CGFloat = 2.0 / 3.0
 }
 
 // MARK: - LayoutEngine
@@ -368,6 +386,10 @@ enum LayoutEngine {
         let columns = workspace.columns
         guard !columns.isEmpty else { return results }
 
+        if config.autoFitEnabled && workspace.isAutoFitEligible {
+            return computeAutoFitFrames(workspace: workspace, config: config)
+        }
+
         let xs = columnXPositions(columns: columns, gap: config.gapWidth)
         let scrollOffset = workspace.viewOffset.current
         let workingArea = workspace.workingArea
@@ -391,6 +413,51 @@ enum LayoutEngine {
             }
         }
 
+        return results
+    }
+
+    static func computeAutoFitFrames(workspace: Workspace, config: LayoutConfig) -> [(WindowID, CGRect)] {
+        var results: [(WindowID, CGRect)] = []
+        let columns = workspace.columns
+        let n = columns.count
+        guard (1...3).contains(n) else { return results }
+
+        let workingArea = workspace.workingArea
+        let gap = config.gapWidth
+        let effectiveWidth = workingArea.width - 2 * gap
+
+        let colWidth: CGFloat
+        var xs: [CGFloat] = []
+        switch n {
+        case 1:
+            colWidth = effectiveWidth * config.autoFitCenterWidthFraction
+            xs = [workingArea.midX - colWidth / 2]
+        case 2:
+            colWidth = (effectiveWidth - gap) / 2
+            let leftX = workingArea.minX + gap
+            xs = [leftX, leftX + colWidth + gap]
+        case 3:
+            colWidth = (effectiveWidth - 2 * gap) / 3
+            let leftX = workingArea.minX + gap
+            xs = [leftX, leftX + colWidth + gap, leftX + (colWidth + gap) * 2]
+        default:
+            return results
+        }
+
+        for (colIdx, column) in columns.enumerated() {
+            let heights = distributeColumnHeight(
+                column: column,
+                availableHeight: workingArea.height,
+                gap: config.gapHeight,
+                focusedIndex: column.activeWindowIndex
+            )
+            for (winIdx, windowID) in column.windows.enumerated() {
+                let (winY, winHeight) = heights[winIdx]
+                let screenY = workingArea.minY + winY
+                let frame = CGRect(x: xs[colIdx], y: screenY, width: colWidth, height: winHeight)
+                results.append((windowID, frame))
+            }
+        }
         return results
     }
 


### PR DESCRIPTION
## Summary

非pinnedカラム数が1〜3のとき、スクロールせず画面を等分/中央配置する **Auto-Fit モード** を追加。

- **1カラム**: 画面幅2/3で中央配置
- **2カラム**: 左右等分
- **3カラム**: 3等分
- **Ctrl+Opt+A** / メニューバー "Auto-Fit Layout" で ON/OFF 切替
- **Ctrl+Opt+R**（カラム幅サイクル）で手動解除、カラム数が閾値(3↔4)をまたぐとリセット
- Pinnedカラムがあるときは自動的に無効

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `Core/Workspace.swift` | `autoFitOverridden` フラグ、`isAutoFitEligible` 算出プロパティ、閾値ロジック |
| `Engine/LayoutEngine.swift` | `computeAutoFitFrames` 新規追加、`computeWindowFrames` に分岐 |
| `Engine/LayoutConfig.swift` | `autoFitEnabled`, `autoFitCenterWidthFraction` |
| `Orchestrator/WindowManager.swift` | `toggleAutoFit()`, cycleColumnWidth の幅固定ロジック、スクロールガード |
| `Bridge/KeyboardShortcutManager.swift` | `.toggleAutoFit` アクション + `Ctrl+Opt+A` バインド |
| `App/NiriMacApp.swift` | メニュー項目 "Auto-Fit Layout" 追加 |
| `Tests/LayoutEngineTests.swift` | Auto-Fit テスト 10 件追加 |
| `Tests/TestTypes.swift` | テスト用型に Auto-Fit 対応を同期 |
| `CLAUDE.md` | ショートカット表更新、カラム幅サイクル仕様修正 |

## 設計判断

- **ハイブリッド自動/手動**: デフォルト自動、`Ctrl+Opt+R` で手動解除。カラム数が閾値を跨いだときのみリセット（範囲内の追加では手動設定を尊重）
- **Auto-Fit 中のスクロール無視**: stale viewOffset による画面ジャンプを防止
- **cycleColumnWidth 時の幅固定**: Auto-Fit 表示幅を全カラムに固定してから cycle 適用（他カラムの急縮小を防止）

## Test plan

- [x] `swift test` — 68 tests passed
- [x] `swift build` — Build complete
- [ ] 実機確認: 1/2/3 カラムでの自動レイアウト
- [ ] 実機確認: `Ctrl+Opt+R` で解除 → 通常スクロールに戻る
- [ ] 実機確認: メニューバー "Auto-Fit Layout" トグル
- [ ] 実機確認: `Ctrl+Opt+A` でトグル

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)