### PR TITLE
feat: スタックされたウィンドウをマウスドラッグで解除可能にする

### DIFF
--- a/Sources/NiriMac/Core/Workspace.swift
+++ b/Sources/NiriMac/Core/Workspace.swift
@@ -264,6 +264,38 @@ struct Workspace {
         }
     }
 
+    /// expelWindow で使う挿入位置
+    enum ExpelInsertSide {
+        case left   // 元カラムの左に新カラム挿入
+        case right  // 元カラムの右に新カラム挿入
+    }
+
+    /// windowID を含むカラムから windowID を抜き出し、新しい1ウィンドウカラムとして挿入する。
+    /// カラムに1ウィンドウしか無い場合、または windowID が見つからない場合は何もせず false を返す。
+    /// 成功時は activeColumnIndex が新カラムを指す。
+    @discardableResult
+    mutating func expelWindow(
+        _ windowID: WindowID,
+        newColumnWidth: CGFloat,
+        insertSide: ExpelInsertSide
+    ) -> Bool {
+        guard let srcColIdx = columnIndex(for: windowID),
+              columns[srcColIdx].windows.count > 1
+        else { return false }
+
+        columns[srcColIdx].removeWindow(windowID)
+
+        let insertIdx: Int
+        switch insertSide {
+        case .left:  insertIdx = srcColIdx
+        case .right: insertIdx = srcColIdx + 1
+        }
+
+        let newColumn = Column(windows: [windowID], width: newColumnWidth)
+        addColumn(newColumn, at: insertIdx)  // addColumn 内で activeColumnIndex = insertIdx
+        return true
+    }
+
     /// ウィンドウIDのカラムインデックスとウィンドウインデックスを返す
     private func findWindowPosition(_ id: WindowID) -> (colIdx: Int, winIdx: Int)? {
         for (colIdx, col) in columns.enumerated() {

--- a/Sources/NiriMac/Orchestrator/WindowManager.swift
+++ b/Sources/NiriMac/Orchestrator/WindowManager.swift
@@ -1093,11 +1093,14 @@ final class WindowManager {
             targetID = windowID; targetFrame = frame; break
         }
 
-        // Priority 2: フレームオーバーラップ最大
+        // Priority 2: フレームオーバーラップ最大（同カラム内ウィンドウは除外）
+        // スタックされたウィンドウは同カラム内で必ずオーバーラップするため、
+        // ここで拾うと expel 分岐に到達できなくなる。
         if targetID == nil, let draggedFrame = axBridge.windowFrame(draggedID) {
             var bestOverlap: CGFloat = 0
             for (windowID, frame) in lastComputedFrames {
-                guard windowID != draggedID else { continue }
+                guard windowID != draggedID,
+                      !isSameColumn(draggedID, windowID) else { continue }
                 let intersection = draggedFrame.intersection(frame)
                 guard !intersection.isNull else { continue }
                 let overlap = intersection.width * intersection.height
@@ -1108,6 +1111,10 @@ final class WindowManager {
         }
 
         guard let target = targetID else {
+            // スタックカラム（2枚以上）からのドラッグをターゲットなし領域にドロップ → expel
+            if tryExpelDraggedWindow(draggedID: draggedID, dropX: point.x, reason: "no-target") {
+                return
+            }
             niriLog("[drag] mouseUp: no target — restoring layout")
             needsLayout = true
             return
@@ -1127,11 +1134,23 @@ final class WindowManager {
         niriLog("[drag] mouseUp: dragged=\(draggedID) target=\(target) zone=\(zone)")
 
         if isSameColumn(draggedID, target) {
-            for i in screens.indices {
-                for j in screens[i].workspaces.indices {
-                    let has1 = screens[i].workspaces[j].columnIndex(for: draggedID) != nil
-                    let has2 = screens[i].workspaces[j].columnIndex(for: target) != nil
-                    if has1 && has2 { screens[i].workspaces[j].swapWindows(draggedID, target); break }
+            // 方向判定: dragged の実位置（AX）と layout 位置の水平差分を測る。
+            // カラム幅の 1/3 を超えたら expel（余白なしでも解除可能）、以下なら swap。
+            let layoutX: CGFloat = lastComputedFrames.first(where: { $0.0 == draggedID })?.1.midX ?? targetFrame.midX
+            let actualX: CGFloat = axBridge.windowFrame(draggedID)?.midX ?? layoutX
+            let horizontalDrift = abs(actualX - layoutX)
+            let expelThreshold = targetFrame.width / 3
+
+            if horizontalDrift > expelThreshold {
+                _ = tryExpelDraggedWindow(draggedID: draggedID, dropX: actualX, reason: "same-col drift=\(Int(horizontalDrift))px")
+            } else {
+                // swap: 同カラム内 reorder
+                for i in screens.indices {
+                    for j in screens[i].workspaces.indices {
+                        let has1 = screens[i].workspaces[j].columnIndex(for: draggedID) != nil
+                        let has2 = screens[i].workspaces[j].columnIndex(for: target) != nil
+                        if has1 && has2 { screens[i].workspaces[j].swapWindows(draggedID, target); break }
+                    }
                 }
             }
         } else {
@@ -1424,6 +1443,37 @@ final class WindowManager {
                 return
             }
         }
+    }
+
+    /// draggedID をスタックカラムから抜き出して新しいカラムとして挿入する共通ヘルパー。
+    /// dropX が元カラム中央より左なら左側、右なら右側に新カラムを挿入する。
+    /// - Returns: expel が発動したら true（カラムが1ウィンドウしかない場合などは false）
+    @discardableResult
+    private func tryExpelDraggedWindow(draggedID: WindowID, dropX: CGFloat, reason: String) -> Bool {
+        for i in screens.indices {
+            for j in screens[i].workspaces.indices {
+                guard let colIdx = screens[i].workspaces[j].columnIndex(for: draggedID) else { continue }
+
+                // 元カラム中央の X を同カラム内ウィンドウのレイアウトフレームから推定
+                let colCenterX: CGFloat = screens[i].workspaces[j].columns[colIdx].windows
+                    .compactMap { wid in self.lastComputedFrames.first(where: { $0.0 == wid })?.1 }
+                    .first.map { $0.midX } ?? dropX
+
+                let side: Workspace.ExpelInsertSide = dropX < colCenterX ? .left : .right
+                let screenWidth = screens[i].frame.width
+                let newColWidth = (windowRegistry[draggedID]?.frame.width ?? 0) > 0
+                    ? windowRegistry[draggedID]!.frame.width
+                    : config.defaultColumnWidth(for: screenWidth)
+
+                if screens[i].workspaces[j].expelWindow(draggedID, newColumnWidth: newColWidth, insertSide: side) {
+                    niriLog("[drag] expel(\(reason)): win=\(draggedID) → \(side == .left ? "left" : "right") of col \(colIdx)")
+                    swapCooldownEnd = Date().addingTimeInterval(0.5)
+                    needsLayout = true
+                    return true
+                }
+            }
+        }
+        return false
     }
 
     private func expelWindowFromColumn(screenIdx: Int) {

--- a/Tests/NiriMacTests/TestTypes.swift
+++ b/Tests/NiriMacTests/TestTypes.swift
@@ -292,6 +292,34 @@ struct Workspace {
         }
     }
 
+    enum ExpelInsertSide {
+        case left
+        case right
+    }
+
+    @discardableResult
+    mutating func expelWindow(
+        _ windowID: WindowID,
+        newColumnWidth: CGFloat,
+        insertSide: ExpelInsertSide
+    ) -> Bool {
+        guard let srcColIdx = columnIndex(for: windowID),
+              columns[srcColIdx].windows.count > 1
+        else { return false }
+
+        columns[srcColIdx].windows.removeAll { $0 == windowID }
+
+        let insertIdx: Int
+        switch insertSide {
+        case .left:  insertIdx = srcColIdx
+        case .right: insertIdx = srcColIdx + 1
+        }
+
+        let newColumn = Column(windows: [windowID], width: newColumnWidth)
+        addColumn(newColumn, at: insertIdx)
+        return true
+    }
+
     var activeWindowID: WindowID? {
         guard !columns.isEmpty, activeColumnIndex < columns.count else { return nil }
         return columns[activeColumnIndex].activeWindowID

--- a/Tests/NiriMacTests/WorkspaceTests.swift
+++ b/Tests/NiriMacTests/WorkspaceTests.swift
@@ -198,4 +198,88 @@ struct WorkspaceTests {
         // 挿入後、activeWindowIndex が draggedID（Win 1）を指す
         #expect(ws.columns[0].activeWindowID == 1)
     }
+
+    // MARK: - expelWindow
+
+    @Test func expelWindow_right_insertsAfterSourceColumn() {
+        // Win 2 を col 0 [1,2,3] から抜き出し、col 0 の右（= col 1）に新カラムとして挿入
+        var ws = Workspace(workingArea: CGRect(x: 0, y: 0, width: 1440, height: 900))
+        ws.columns = [
+            Column(windows: [1, 2, 3], width: 400),
+            Column(windows: [4], width: 400),
+        ]
+        ws.activeColumnIndex = 0
+
+        let result = ws.expelWindow(2, newColumnWidth: 400, insertSide: .right)
+
+        #expect(result == true)
+        #expect(ws.columns.count == 3)
+        #expect(ws.columns[0].windows == [1, 3])
+        #expect(ws.columns[1].windows == [2])
+        #expect(ws.columns[2].windows == [4])
+    }
+
+    @Test func expelWindow_left_insertsBeforeSourceColumn() {
+        // Win 2 を col 0 [1,2,3] から抜き出し、col 0 の左（= col 0）に新カラムとして挿入
+        var ws = Workspace(workingArea: CGRect(x: 0, y: 0, width: 1440, height: 900))
+        ws.columns = [
+            Column(windows: [1, 2, 3], width: 400),
+            Column(windows: [4], width: 400),
+        ]
+        ws.activeColumnIndex = 0
+
+        let result = ws.expelWindow(2, newColumnWidth: 400, insertSide: .left)
+
+        #expect(result == true)
+        #expect(ws.columns.count == 3)
+        #expect(ws.columns[0].windows == [2])
+        #expect(ws.columns[1].windows == [1, 3])
+        #expect(ws.columns[2].windows == [4])
+    }
+
+    @Test func expelWindow_singleWindowColumn_returnsFalseAndIsNoop() {
+        var ws = Workspace(workingArea: CGRect(x: 0, y: 0, width: 1440, height: 900))
+        ws.columns = [Column(windows: [1], width: 400)]
+
+        let result = ws.expelWindow(1, newColumnWidth: 400, insertSide: .right)
+
+        #expect(result == false)
+        #expect(ws.columns.count == 1)
+        #expect(ws.columns[0].windows == [1])
+    }
+
+    @Test func expelWindow_windowNotFound_returnsFalseAndIsNoop() {
+        var ws = Workspace(workingArea: CGRect(x: 0, y: 0, width: 1440, height: 900))
+        ws.columns = [Column(windows: [1, 2], width: 400)]
+
+        let result = ws.expelWindow(99, newColumnWidth: 400, insertSide: .right)
+
+        #expect(result == false)
+        #expect(ws.columns.count == 1)
+        #expect(ws.columns[0].windows == [1, 2])
+    }
+
+    @Test func expelWindow_setsFocusToNewColumn() {
+        var ws = Workspace(workingArea: CGRect(x: 0, y: 0, width: 1440, height: 900))
+        ws.columns = [
+            Column(windows: [1, 2], width: 400),
+            Column(windows: [3], width: 400),
+        ]
+        ws.activeColumnIndex = 0
+
+        ws.expelWindow(2, newColumnWidth: 400, insertSide: .right)
+
+        // 新カラムが activeColumnIndex で参照できる
+        #expect(ws.activeColumnIndex == 1)
+        #expect(ws.columns[ws.activeColumnIndex].windows == [2])
+    }
+
+    @Test func expelWindow_usesSpecifiedWidth() {
+        var ws = Workspace(workingArea: CGRect(x: 0, y: 0, width: 1440, height: 900))
+        ws.columns = [Column(windows: [1, 2], width: 400)]
+
+        ws.expelWindow(2, newColumnWidth: 600, insertSide: .right)
+
+        #expect(ws.columns[1].width == 600)
+    }
 }


### PR DESCRIPTION
## Summary
- 同カラム内の水平ドラッグ（カラム幅1/3超）で expel 発動
- 空き領域ドロップでも expel 発動（カラムが画面を埋めていても可）
- Priority 2 オーバーラップ検出から同カラム内ウィンドウを除外
- `Workspace.expelWindow` を pure function として抽出し unit test 6件追加

## Background
スタックされたウィンドウが mouse drag で解除できない問題。従来は `handleMouseUp` の target 検出 Priority 2（フレームオーバーラップ最大）で同一カラム内の他ウィンドウが必ず拾われ、`isSameColumn` → 強制 swap となり expel 分岐に到達できなかった。

## Test plan
- [x] 全 unit test 通過（64 tests: 既存58 + 新規6）
- [ ] スタック内ウィンドウを**横に大きくドラッグ**（カラム幅1/3超） → expel発動（ログ: `[drag] expel(same-col drift=XXXpx)`）
- [ ] スタック内ウィンドウを**空き領域へドロップ** → expel発動（ログ: `[drag] expel(no-target)`）
- [ ] スタック内の縦ドラッグ（別ウィンドウ上にドロップ） → 従来通り swap（reorder）
- [ ] 別カラムの edge zone へドロップ → 従来通り insertLeft/insertRight
- [ ] 別カラムの中央ゾーンへドロップ → 従来通り stackAbove/Below/swap
- [ ] キーボード `Ctrl+Opt+Shift+Return` で expel → 従来通り動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)