### PR TITLE
fix: AX属性未準備によるウィンドウ取りこぼしをリトライで解消

### DIFF
--- a/Sources/NiriMac/Bridge/AXObserverBridge.swift
+++ b/Sources/NiriMac/Bridge/AXObserverBridge.swift
@@ -120,6 +120,21 @@ final class AXObserverBridge {
         AXObserverAddNotification(obs, windowElement, kAXUIElementDestroyedNotification as CFString, selfPtr)
     }
 
+    /// kAXWindowCreatedNotification 発火時に AX 属性が未準備の場合のリトライ
+    private func retryWindowCreated(element: AXUIElement, pid: pid_t, remainingDelays: [Double]) {
+        guard let delay = remainingDelays.first else { return }
+        let nextDelays = Array(remainingDelays.dropFirst())
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard let self else { return }
+            if let info = WindowInfo(axElement: element, ownerPID: pid),
+               WindowInfo.isManageable(axElement: element) {
+                self.onWindowCreated?(info)
+            } else if !nextDelays.isEmpty {
+                self.retryWindowCreated(element: element, pid: pid, remainingDelays: nextDelays)
+            }
+        }
+    }
+
     private func removeObserver(for pid: pid_t) {
         observers.removeValue(forKey: pid)
     }
@@ -139,6 +154,10 @@ final class AXObserverBridge {
                 DispatchQueue.main.async { [weak self] in
                     self?.onWindowCreated?(info)
                 }
+            } else {
+                // ウィンドウの AX 属性がまだ準備できていない場合（Electron/JVM 系で発生）
+                // 短い間隔でリトライして取りこぼしを防ぐ
+                retryWindowCreated(element: element, pid: pid, remainingDelays: [0.1, 0.3, 1.0])
             }
 
         case elementDestroyed:


### PR DESCRIPTION
## Summary
- `kAXWindowCreatedNotification` 発火時に `WindowInfo` 初期化や `isManageable` チェックが失敗するケース（Electron/JVM 系アプリで AX 属性の準備が遅延）に対応
- 初回失敗時は `0.1s → 0.3s → 1.0s` のリトライロジックを追加し、ウィンドウの取りこぼしを防ぐ
- 変更は `Sources/NiriMac/Bridge/AXObserverBridge.swift` の +19 行のみ

## Test plan
- [ ] Electron 系アプリ（Discord, Slack, VS Code）でウィンドウ新規作成時に取りこぼしがないか確認
- [ ] JVM 系アプリ（IntelliJ IDEA 等）でも同様に確認
- [ ] 通常の AppKit アプリで既存の管理動作が壊れていないか確認
- [ ] `/tmp/niri-mac.log` に retry ログが出ることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)