### PR TITLE
fix: re-enable CGEventTap after tapDisabledByTimeout/UserInput

### DIFF
--- a/Sources/NiriMac/Bridge/KeyboardShortcutManager.swift
+++ b/Sources/NiriMac/Bridge/KeyboardShortcutManager.swift
@@ -143,11 +143,20 @@ final class KeyboardShortcutManager {
             place: .headInsertEventTap,
             options: .listenOnly,
             eventsOfInterest: eventMask,
-            callback: { _, _, event, refcon -> Unmanaged<CGEvent>? in
+            callback: { _, type, event, refcon -> Unmanaged<CGEvent>? in
                 guard let refcon = refcon else {
                     return Unmanaged.passRetained(event)
                 }
                 let manager = Unmanaged<KeyboardShortcutManager>.fromOpaque(refcon).takeUnretainedValue()
+                // システムがタップを無効化した時は即再有効化する（放置するとキーショートカットが永続的に効かなくなる）
+                if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+                    let reason = type == .tapDisabledByTimeout ? "timeout" : "userInput"
+                    kbLog("[tap] ⚠️ keyboard tap disabled by \(reason) — re-enabling")
+                    if let tap = manager.eventTap {
+                        CGEvent.tapEnable(tap: tap, enable: true)
+                    }
+                    return Unmanaged.passRetained(event)
+                }
                 manager.handleCGEvent(event)
                 return Unmanaged.passRetained(event)
             },

--- a/Sources/NiriMac/Bridge/MouseEventManager.swift
+++ b/Sources/NiriMac/Bridge/MouseEventManager.swift
@@ -102,6 +102,17 @@ final class MouseEventManager {
     /// イベントを処理する。戻り値が true のときそのイベントをアプリへ転送しない。
     @discardableResult
     private func handleCGEvent(type: CGEventType, event: CGEvent) -> Bool {
+        // システムがタップを無効化した時は即再有効化する。
+        // 放置すると Option+スクロール等が永続的に効かなくなる。
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            let reason = type == .tapDisabledByTimeout ? "timeout" : "userInput"
+            mouseLog("[tap] ⚠️ mouse tap disabled by \(reason) — re-enabling")
+            if let tap = eventTap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
+            return false
+        }
+
         switch type {
         case .leftMouseDown:
             let loc = event.location


### PR DESCRIPTION
Closes #16

## Summary

- CGEventTap が `.tapDisabledByTimeout` / `.tapDisabledByUserInput` で無効化された際の再有効化処理を追加
- `MouseEventManager` と `KeyboardShortcutManager` の両コールバックに同じ穴があったので一緒に修正
- 事象発生時は `/tmp/niri-mac.log` に `[tap] ⚠️ ... disabled by ... — re-enabling` を出力して可視化

## Why

macOS は CGEventTap のコールバック処理が遅い（約 1 秒以上）と判定すると、そのタップを自動的に無効化する。明示的に `CGEvent.tapEnable(tap:enable: true)` を呼ばない限り永続的に停止する仕様。

現状のコードは `.tapDisabledByTimeout` / `.tapDisabledByUserInput` のイベントタイプを受けても `default` に落ちてそのまま `return` していたため、一度無効化されるとアプリを再起動するまでマウスイベント（Option+スクロール含む）やキーボードショートカットが効かなくなっていた。

## Changes

- **`Sources/NiriMac/Bridge/MouseEventManager.swift`**: `handleCGEvent(type:event:)` 冒頭で tap 無効化イベントを検知し、`eventTap` に対して `tapEnable(enable: true)` を呼び直す。
- **`Sources/NiriMac/Bridge/KeyboardShortcutManager.swift`**: `startCGEventTap` の callback 冒頭で同様の処理を実装。`refcon` 経由で `manager.eventTap` を参照する。

## Test plan

- [ ] ビルドが通る (`swift build`) ✅ 確認済み
- [ ] アプリ起動後、Option+スクロールが動作することを確認
- [ ] 長時間運用後（高負荷操作を挟んだ後）に Option+スクロールが継続して動作することを確認
- [ ] 無効化が発生した場合、`/tmp/niri-mac.log` に `[tap] ⚠️ ... disabled by ...` が出力され、その直後に再度スクロールが効くことを確認