### PR TITLE
fix: reverse scroll direction so right-swipe shows right content

### DIFF
--- a/Sources/NiriMac/Core/Workspace.swift
+++ b/Sources/NiriMac/Core/Workspace.swift
@@ -339,4 +339,26 @@ struct Workspace {
             }
         }
     }
+
+    // MARK: - Scroll
+
+    /// スクロール delta を viewOffset に適用する。
+    /// - deltaX: 正 = 右スワイプ（macOS ナチュラルスクロール）→ viewOffset を負方向へ
+    /// - sensitivity: 感度係数
+    /// - isContinuous: true = トラックパッド（static 更新）、false = マウスホイール（アニメーション）
+    mutating func applyScrollDelta(deltaX: CGFloat, sensitivity: CGFloat, isContinuous: Bool, gap: CGFloat = 16) {
+        let delta = -deltaX * sensitivity   // 右スワイプ(+) → オフセット負方向
+
+        let current = viewOffset.current
+        let xs = columnXPositions(gap: gap)
+        let lastX = (xs.last ?? 0) + (columns.last?.width ?? 0)
+        let minOffset = min(0, workingArea.width - gap - lastX)
+        let newOffset = max(minOffset, min(0, current + delta))
+
+        if isContinuous {
+            viewOffset = .static(offset: newOffset)
+        } else {
+            viewOffset.animateTo(newOffset)
+        }
+    }
 }

--- a/Sources/NiriMac/Orchestrator/WindowManager.swift
+++ b/Sources/NiriMac/Orchestrator/WindowManager.swift
@@ -1344,25 +1344,12 @@ final class WindowManager {
 
     private func applyLayoutScroll(effectiveDeltaX: CGFloat, sensitivity: CGFloat, isContinuous: Bool, screenIdx: Int) {
         // Auto-Fit 中はスクロール自体が無意味なので viewOffset を触らない
-        // （触ると解除時に stale オフセットでレイアウトが飛ぶ）
         if config.autoFitEnabled && screens[screenIdx].activeWorkspace.isAutoFitEligible {
             return
         }
 
-        let delta = effectiveDeltaX * sensitivity
-
         var ws = screens[screenIdx].activeWorkspace
-        let current = ws.viewOffset.current
-        let xs = ws.columnXPositions(gap: config.gapWidth)
-        let lastX = (xs.last ?? 0) + (ws.columns.last?.width ?? 0)
-        let minOffset = min(0, ws.workingArea.width - config.gapWidth - lastX)
-        let newOffset = max(minOffset, min(0, current + delta))
-
-        if isContinuous {
-            ws.viewOffset = .static(offset: newOffset)
-        } else {
-            ws.viewOffset.animateTo(newOffset)
-        }
+        ws.applyScrollDelta(deltaX: effectiveDeltaX, sensitivity: sensitivity, isContinuous: isContinuous, gap: config.gapWidth)
         screens[screenIdx].activeWorkspace = ws
         needsLayout = true
     }

--- a/Tests/NiriMacTests/ScrollDirectionTests.swift
+++ b/Tests/NiriMacTests/ScrollDirectionTests.swift
@@ -1,0 +1,70 @@
+import Testing
+import CoreGraphics
+@testable import NiriMac
+
+@Suite("Scroll Direction Tests")
+struct ScrollDirectionTests {
+
+    // 右スワイプ（deltaX > 0）で右のコンテンツが見える（viewOffset が負方向）
+    @Test func rightSwipe_movesViewOffsetNegative() {
+        var ws = NiriMac.Workspace(workingArea: CGRect(x: 0, y: 0, width: 1440, height: 900))
+        ws.columns = [
+            NiriMac.Column(windows: [1], width: 480),
+            NiriMac.Column(windows: [2], width: 480),
+            NiriMac.Column(windows: [3], width: 480),
+        ]
+        ws.viewOffset = .static(offset: 0)
+
+        ws.applyScrollDelta(deltaX: 10.0, sensitivity: 1.0, isContinuous: true)
+
+        #expect(ws.viewOffset.current < 0)
+    }
+
+    // 左スワイプ（deltaX < 0）でオフセットが 0 方向（左コンテンツ方向）
+    @Test func leftSwipe_doesNotGoPositive() {
+        var ws = NiriMac.Workspace(workingArea: CGRect(x: 0, y: 0, width: 1440, height: 900))
+        ws.columns = [
+            NiriMac.Column(windows: [1], width: 480),
+            NiriMac.Column(windows: [2], width: 480),
+            NiriMac.Column(windows: [3], width: 480),
+        ]
+        ws.viewOffset = .static(offset: -200)
+
+        ws.applyScrollDelta(deltaX: -10.0, sensitivity: 1.0, isContinuous: true)
+
+        #expect(ws.viewOffset.current <= 0)
+        #expect(ws.viewOffset.current > -200)
+    }
+
+    // minOffset クランプ: コンテンツ端を超えてスクロールしない
+    @Test func rightSwipe_clampedAtMinOffset() {
+        var ws = NiriMac.Workspace(workingArea: CGRect(x: 0, y: 0, width: 800, height: 900))
+        ws.columns = [
+            NiriMac.Column(windows: [1], width: 480),
+            NiriMac.Column(windows: [2], width: 480),
+            NiriMac.Column(windows: [3], width: 480),
+        ]
+        ws.viewOffset = .static(offset: -700)
+
+        ws.applyScrollDelta(deltaX: 1000.0, sensitivity: 1.0, isContinuous: true)
+
+        #expect(ws.viewOffset.current >= -728)
+    }
+
+    // deltaX=0 はオフセットを変えない
+    @Test func zeroDelta_noChange() {
+        // workingArea=800, 3カラム×480+gap → minOffset = 800-16-(480*3+16*2) = 800-16-1472 = -688
+        // -100 は minOffset より大きいのでクランプされない
+        var ws = NiriMac.Workspace(workingArea: CGRect(x: 0, y: 0, width: 800, height: 900))
+        ws.columns = [
+            NiriMac.Column(windows: [1], width: 480),
+            NiriMac.Column(windows: [2], width: 480),
+            NiriMac.Column(windows: [3], width: 480),
+        ]
+        ws.viewOffset = .static(offset: -100)
+
+        ws.applyScrollDelta(deltaX: 0, sensitivity: 1.0, isContinuous: true)
+
+        #expect(abs(ws.viewOffset.current - (-100)) < 0.001)
+    }
+}


### PR DESCRIPTION
## Summary

- スクロール方向が逆だったバグを修正
- 右スワイプ（`deltaX > 0`）で右のコンテンツが見えるようになった
- `Workspace.applyScrollDelta` にロジックを切り出し、`delta = -deltaX * sensitivity` で符号を修正

## 変更詳細

**原因:** `applyLayoutScroll` の `delta = effectiveDeltaX * sensitivity` が正のまま加算され、右スワイプで `viewOffset` が 0 方向（左コンテンツ方向）に動いていた。

**修正:**
- `Workspace.applyScrollDelta(deltaX:sensitivity:isContinuous:gap:)` を新規追加（`delta = -deltaX * sensitivity`）
- `WindowManager.applyLayoutScroll` を薄いラッパーに変更

## Test plan

- [x] `ScrollDirectionTests` 4件追加（右スワイプ・左スワイプ・クランプ・deltaX=0）
- [x] `swift test` 全84件 PASS
- [x] `swift build` + `make-app.sh` ビルド成功
- [x] 実機でスクロール方向を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)