### PR TITLE
fix: set AX messaging timeout to prevent main thread freeze

### DIFF
--- a/Sources/NiriMac/Bridge/AccessibilityBridge.swift
+++ b/Sources/NiriMac/Bridge/AccessibilityBridge.swift
@@ -50,6 +50,7 @@ final class AccessibilityBridge: AccessibilityBridgeProtocol {
                 else { continue }
 
                 windows.append(info)
+                AXUIElementSetMessagingTimeout(axWindow, 0.5)
                 elementCache[info.id] = axWindow
             }
         }
@@ -117,6 +118,9 @@ final class AccessibilityBridge: AccessibilityBridgeProtocol {
 
     /// AXUIElement を elementCache に登録
     func registerElement(_ element: AXUIElement, for id: WindowID) {
+        // AXUIElementSetAttributeValue がメインスレッドをブロックする時間を制限する。
+        // デフォルト(~6秒)のままだと tapDisabledByTimeout が発生してクリックが届かなくなる。
+        AXUIElementSetMessagingTimeout(element, 0.5)
         elementCache[id] = element
     }
 


### PR DESCRIPTION
## Summary

- `AXUIElementSetMessagingTimeout(element, 0.5)` を `allWindows()` と `registerElement(_:for:)` の2箇所に追加
- AX API 呼び出しが無応答アプリに対して無限ブロックするのを防ぐ

## 根本原因

`AXUIElementSetAttributeValue`（`setWindowFrame` / `focusWindow` 内）はメインスレッドで同期実行される。対象アプリが AX イベントに応答しない場合、デフォルトのタイムアウト（実質∞）でメインスレッドが永遠にブロックされる。

```
対象アプリがフリーズ
  ↓ AXUIElementSetAttributeValue が永遠にブロック
  ↓ メインスレッドが止まる
  ↓ CGEventTap コールバックが実行できない
  ↓ tapDisabledByTimeout → 再有効化も不可（メインスレッドがブロック中）
  ↓ マウスイベントが全てドロップ → 再起動が必要
```

## 修正

各 `AXUIElement` に `AXUIElementSetMessagingTimeout(element, 0.5)` を設定し、AX API 呼び出しを最大 0.5 秒でタイムアウトさせる。これによりメインスレッドのブロックが制限され、CGEventTap が正常に機能し続ける。

## Test plan

- [ ] 通常操作でクリック・スクロールが正常に機能することを確認
- [ ] 重い処理中のアプリをクリックしても niri がフリーズしないことを確認
- [ ] 長時間使用後も再起動不要なことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)