### PR TITLE
feat: make keyboard and scroll modifier keys configurable

### DIFF
--- a/Sources/NiriMac/App/ModifierSettingsView.swift
+++ b/Sources/NiriMac/App/ModifierSettingsView.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+import AppKit
+
+final class ModifierSettingsModel: ObservableObject {
+    @Published var metaControl: Bool
+    @Published var metaOption: Bool
+    @Published var metaCommand: Bool
+    @Published var metaShift: Bool
+
+    @Published var layoutControl: Bool
+    @Published var layoutOption: Bool
+    @Published var layoutCommand: Bool
+    @Published var layoutShift: Bool
+
+    @Published var focusControl: Bool
+    @Published var focusOption: Bool
+    @Published var focusCommand: Bool
+    @Published var focusShift: Bool
+
+    private let originalMeta: NSEvent.ModifierFlags
+    private let originalScrollLayout: NSEvent.ModifierFlags
+    private let originalScrollFocus: NSEvent.ModifierFlags
+
+    init(meta: NSEvent.ModifierFlags, scrollLayout: NSEvent.ModifierFlags, scrollFocus: NSEvent.ModifierFlags) {
+        self.originalMeta = meta
+        self.originalScrollLayout = scrollLayout
+        self.originalScrollFocus = scrollFocus
+
+        metaControl = meta.contains(.control)
+        metaOption  = meta.contains(.option)
+        metaCommand = meta.contains(.command)
+        metaShift   = meta.contains(.shift)
+
+        layoutControl = scrollLayout.contains(.control)
+        layoutOption  = scrollLayout.contains(.option)
+        layoutCommand = scrollLayout.contains(.command)
+        layoutShift   = scrollLayout.contains(.shift)
+
+        focusControl = scrollFocus.contains(.control)
+        focusOption  = scrollFocus.contains(.option)
+        focusCommand = scrollFocus.contains(.command)
+        focusShift   = scrollFocus.contains(.shift)
+    }
+
+    var currentMeta: NSEvent.ModifierFlags {
+        flags(metaControl, metaOption, metaCommand, metaShift)
+    }
+
+    var currentScrollLayout: NSEvent.ModifierFlags {
+        flags(layoutControl, layoutOption, layoutCommand, layoutShift)
+    }
+
+    var currentScrollFocus: NSEvent.ModifierFlags {
+        flags(focusControl, focusOption, focusCommand, focusShift)
+    }
+
+    var hasChanges: Bool {
+        currentMeta != originalMeta ||
+        currentScrollLayout != originalScrollLayout ||
+        currentScrollFocus != originalScrollFocus
+    }
+
+    var anyEmpty: Bool {
+        currentMeta.isEmpty || currentScrollLayout.isEmpty || currentScrollFocus.isEmpty
+    }
+
+    var metaHasCommand: Bool { metaCommand }
+
+    private func flags(_ c: Bool, _ o: Bool, _ cmd: Bool, _ s: Bool) -> NSEvent.ModifierFlags {
+        var f: NSEvent.ModifierFlags = []
+        if c   { f.insert(.control) }
+        if o   { f.insert(.option) }
+        if cmd { f.insert(.command) }
+        if s   { f.insert(.shift) }
+        return f
+    }
+}
+
+struct ModifierSettingsView: View {
+    @ObservedObject var model: ModifierSettingsModel
+    var onCancel: () -> Void
+    var onApply: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            GroupBox("Keyboard Meta") {
+                modifierGrid(
+                    control: $model.metaControl,
+                    option:  $model.metaOption,
+                    command: $model.metaCommand,
+                    shift:   $model.metaShift,
+                    isEmpty: model.currentMeta.isEmpty
+                )
+                if model.metaHasCommand {
+                    Label("Command はワークスペース操作と競合します", systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                }
+            }
+
+            GroupBox("Scroll: Layout") {
+                modifierGrid(
+                    control: $model.layoutControl,
+                    option:  $model.layoutOption,
+                    command: $model.layoutCommand,
+                    shift:   $model.layoutShift,
+                    isEmpty: model.currentScrollLayout.isEmpty
+                )
+            }
+
+            GroupBox("Scroll: Focus") {
+                modifierGrid(
+                    control: $model.focusControl,
+                    option:  $model.focusOption,
+                    command: $model.focusCommand,
+                    shift:   $model.focusShift,
+                    isEmpty: model.currentScrollFocus.isEmpty
+                )
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                Button("Restart to Apply") {
+                    ConfigStore.save(
+                        meta: model.currentMeta,
+                        scrollLayout: model.currentScrollLayout,
+                        scrollFocus: model.currentScrollFocus
+                    )
+                    onApply()
+                }
+                .disabled(!model.hasChanges || model.anyEmpty)
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(20)
+        .frame(width: 360)
+    }
+
+    @ViewBuilder
+    private func modifierGrid(
+        control: Binding<Bool>,
+        option:  Binding<Bool>,
+        command: Binding<Bool>,
+        shift:   Binding<Bool>,
+        isEmpty: Bool
+    ) -> some View {
+        Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 4) {
+            GridRow {
+                Toggle("Control (⌃)", isOn: control)
+                Toggle("Option (⌥)",  isOn: option)
+            }
+            GridRow {
+                Toggle("Command (⌘)", isOn: command)
+                Toggle("Shift (⇧)",   isOn: shift)
+            }
+        }
+        .padding(.vertical, 4)
+        if isEmpty {
+            Text("最低1つ選択してください")
+                .font(.caption)
+                .foregroundColor(.red)
+        }
+    }
+}

--- a/Sources/NiriMac/App/ModifierSettingsWindowController.swift
+++ b/Sources/NiriMac/App/ModifierSettingsWindowController.swift
@@ -26,7 +26,7 @@ final class ModifierSettingsWindowController: NSWindowController {
         )
 
         let panel = NSPanel(
-            contentRect: NSRect(x: 0, y: 0, width: 360, height: 100),
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 420),
             styleMask: [.titled, .closable, .utilityWindow],
             backing: .buffered,
             defer: false

--- a/Sources/NiriMac/App/ModifierSettingsWindowController.swift
+++ b/Sources/NiriMac/App/ModifierSettingsWindowController.swift
@@ -1,0 +1,66 @@
+import AppKit
+import SwiftUI
+
+final class ModifierSettingsWindowController: NSWindowController {
+
+    private static var shared: ModifierSettingsWindowController?
+
+    static func show() {
+        if let existing = shared {
+            existing.window?.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+        let controller = ModifierSettingsWindowController()
+        shared = controller
+        controller.showWindow(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private init() {
+        let stored = ConfigStore.load()
+        let model = ModifierSettingsModel(
+            meta: stored.meta,
+            scrollLayout: stored.scrollLayout,
+            scrollFocus: stored.scrollFocus
+        )
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 100),
+            styleMask: [.titled, .closable, .utilityWindow],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = "Modifier Key Settings"
+        panel.isReleasedWhenClosed = false
+        panel.center()
+
+        super.init(window: panel)
+
+        let view = ModifierSettingsView(
+            model: model,
+            onCancel: { [weak self] in self?.close() },
+            onApply:  { [weak self] in
+                self?.close()
+                ModifierSettingsWindowController.relaunch()
+            }
+        )
+        panel.contentViewController = NSHostingController(rootView: view)
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    override func close() {
+        super.close()
+        Self.shared = nil
+    }
+
+    private static func relaunch() {
+        let bundlePath = Bundle.main.bundlePath
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/sh")
+        task.arguments = ["-c", "sleep 0.5; exec /usr/bin/open \"$1\"", "sh", bundlePath]
+        try? task.run()
+        NSApplication.shared.terminate(nil)
+    }
+}

--- a/Sources/NiriMac/App/NiriMacApp.swift
+++ b/Sources/NiriMac/App/NiriMacApp.swift
@@ -11,12 +11,26 @@ final class NiriMacApp: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var focusDimMenuItem: NSMenuItem?
     private var autoFitMenuItem: NSMenuItem?
     private var excludedAppsMenuItem: NSMenuItem?
+    private var pendingMeta: NSEvent.ModifierFlags = [.control, .option]
+    private var pendingScrollLayout: NSEvent.ModifierFlags = [.option]
+    private var pendingScrollFocus: NSEvent.ModifierFlags = [.control, .option]
+    private var modifierChangePending = false
+    private var restartMenuItem: NSMenuItem?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         printDiagnostics()
+
+        let stored = ConfigStore.load()
+        pendingMeta = stored.meta
+        pendingScrollLayout = stored.scrollLayout
+        pendingScrollFocus = stored.scrollFocus
+
         setupStatusBar()
 
-        let config = LayoutConfig()
+        var config = LayoutConfig()
+        config.metaModifiers = stored.meta
+        config.scrollLayoutModifiers = stored.scrollLayout
+        config.scrollFocusModifiers = stored.scrollFocus
         windowManager = WindowManager(config: config)
         windowManager?.start()
     }
@@ -92,8 +106,92 @@ final class NiriMacApp: NSObject, NSApplicationDelegate, NSMenuDelegate {
         menu.addItem(reLayoutItem)
 
         menu.addItem(NSMenuItem.separator())
+        menu.addItem(makeModifierSubmenu(title: "Keyboard Meta", current: pendingMeta, tag: 1))
+        menu.addItem(makeModifierSubmenu(title: "Scroll: Layout", current: pendingScrollLayout, tag: 2))
+        menu.addItem(makeModifierSubmenu(title: "Scroll: Focus", current: pendingScrollFocus, tag: 3))
+
+        let restartItem = NSMenuItem(title: "Restart to Apply...", action: #selector(restartToApply), keyEquivalent: "")
+        restartItem.target = self
+        restartItem.isEnabled = false
+        self.restartMenuItem = restartItem
+        menu.addItem(restartItem)
+
+        menu.addItem(NSMenuItem.separator())
         menu.addItem(withTitle: "Quit", action: #selector(quit), keyEquivalent: "q")
         statusItem?.menu = menu
+    }
+
+    private func makeModifierSubmenu(title: String, current: NSEvent.ModifierFlags, tag: Int) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        let submenu = NSMenu()
+        let pairs: [(String, NSEvent.ModifierFlags)] = [
+            ("Control (⌃)", .control),
+            ("Option (⌥)",  .option),
+            ("Command (⌘)", .command),
+            ("Shift (⇧)",   .shift),
+        ]
+        for (i, (label, flag)) in pairs.enumerated() {
+            let mi = NSMenuItem(title: label, action: #selector(toggleModifier(_:)), keyEquivalent: "")
+            mi.target = self
+            mi.state = current.contains(flag) ? .on : .off
+            mi.tag = tag * 10 + i
+            submenu.addItem(mi)
+        }
+        submenu.addItem(NSMenuItem.separator())
+        submenu.addItem(NSMenuItem(title: "(再起動後に反映)", action: nil, keyEquivalent: ""))
+        item.submenu = submenu
+        return item
+    }
+
+    private static let modifierFlagList: [NSEvent.ModifierFlags] = [.control, .option, .command, .shift]
+
+    @objc private func toggleModifier(_ sender: NSMenuItem) {
+        let group = sender.tag / 10
+        let flagIndex = sender.tag % 10
+        guard flagIndex < NiriMacApp.modifierFlagList.count else { return }
+        let flag = NiriMacApp.modifierFlagList[flagIndex]
+
+        switch group {
+        case 1:
+            if pendingMeta.contains(flag) { pendingMeta.remove(flag) } else { pendingMeta.insert(flag) }
+            if pendingMeta.isEmpty { pendingMeta.insert(flag); return }
+            sender.state = pendingMeta.contains(flag) ? .on : .off
+            if pendingMeta.contains(.command) {
+                let alert = NSAlert()
+                alert.messageText = "⚠️ Command をメタキーに含めると\nワークスペース操作が機能しなくなります"
+                alert.alertStyle = .warning
+                alert.addButton(withTitle: "OK")
+                alert.runModal()
+            }
+        case 2:
+            if pendingScrollLayout.contains(flag) { pendingScrollLayout.remove(flag) } else { pendingScrollLayout.insert(flag) }
+            if pendingScrollLayout.isEmpty { pendingScrollLayout.insert(flag); return }
+            sender.state = pendingScrollLayout.contains(flag) ? .on : .off
+        case 3:
+            if pendingScrollFocus.contains(flag) { pendingScrollFocus.remove(flag) } else { pendingScrollFocus.insert(flag) }
+            if pendingScrollFocus.isEmpty { pendingScrollFocus.insert(flag); return }
+            sender.state = pendingScrollFocus.contains(flag) ? .on : .off
+        default:
+            return
+        }
+
+        ConfigStore.save(meta: pendingMeta, scrollLayout: pendingScrollLayout, scrollFocus: pendingScrollFocus)
+        modifierChangePending = true
+        restartMenuItem?.isEnabled = true
+    }
+
+    @objc private func restartToApply() {
+        let alert = NSAlert()
+        alert.messageText = "再起動して設定変更を適用しますか？"
+        alert.addButton(withTitle: "再起動")
+        alert.addButton(withTitle: "キャンセル")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let bundlePath = Bundle.main.bundlePath
+        let task = Process()
+        task.launchPath = "/bin/sh"
+        task.arguments = ["-c", "sleep 0.5; open '\(bundlePath)'"]
+        try? task.run()
+        NSApplication.shared.terminate(nil)
     }
 
     /// メニューが開く直前にアクティブカラムの pin 状態を記録してタイトルを更新する

--- a/Sources/NiriMac/App/NiriMacApp.swift
+++ b/Sources/NiriMac/App/NiriMacApp.swift
@@ -14,7 +14,6 @@ final class NiriMacApp: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var pendingMeta: NSEvent.ModifierFlags = [.control, .option]
     private var pendingScrollLayout: NSEvent.ModifierFlags = [.option]
     private var pendingScrollFocus: NSEvent.ModifierFlags = [.control, .option]
-    private var modifierChangePending = false
     private var restartMenuItem: NSMenuItem?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -156,7 +155,7 @@ final class NiriMacApp: NSObject, NSApplicationDelegate, NSMenuDelegate {
             if pendingMeta.contains(flag) { pendingMeta.remove(flag) } else { pendingMeta.insert(flag) }
             if pendingMeta.isEmpty { pendingMeta.insert(flag); return }
             sender.state = pendingMeta.contains(flag) ? .on : .off
-            if pendingMeta.contains(.command) {
+            if flag == .command && pendingMeta.contains(.command) {
                 let alert = NSAlert()
                 alert.messageText = "⚠️ Command をメタキーに含めると\nワークスペース操作が機能しなくなります"
                 alert.alertStyle = .warning
@@ -176,7 +175,6 @@ final class NiriMacApp: NSObject, NSApplicationDelegate, NSMenuDelegate {
         }
 
         ConfigStore.save(meta: pendingMeta, scrollLayout: pendingScrollLayout, scrollFocus: pendingScrollFocus)
-        modifierChangePending = true
         restartMenuItem?.isEnabled = true
     }
 
@@ -187,10 +185,12 @@ final class NiriMacApp: NSObject, NSApplicationDelegate, NSMenuDelegate {
         alert.addButton(withTitle: "キャンセル")
         guard alert.runModal() == .alertFirstButtonReturn else { return }
         let bundlePath = Bundle.main.bundlePath
-        let task = Process()
-        task.launchPath = "/bin/sh"
-        task.arguments = ["-c", "sleep 0.5; open '\(bundlePath)'"]
-        try? task.run()
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+            let task = Process()
+            task.launchPath = "/usr/bin/open"
+            task.arguments = [bundlePath]
+            try? task.run()
+        }
         NSApplication.shared.terminate(nil)
     }
 

--- a/Sources/NiriMac/App/NiriMacApp.swift
+++ b/Sources/NiriMac/App/NiriMacApp.swift
@@ -185,12 +185,10 @@ final class NiriMacApp: NSObject, NSApplicationDelegate, NSMenuDelegate {
         alert.addButton(withTitle: "キャンセル")
         guard alert.runModal() == .alertFirstButtonReturn else { return }
         let bundlePath = Bundle.main.bundlePath
-        DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
-            let task = Process()
-            task.launchPath = "/usr/bin/open"
-            task.arguments = [bundlePath]
-            try? task.run()
-        }
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/sh")
+        task.arguments = ["-c", "sleep 0.5; exec /usr/bin/open \"$1\"", "sh", bundlePath]
+        try? task.run()
         NSApplication.shared.terminate(nil)
     }
 

--- a/Sources/NiriMac/App/NiriMacApp.swift
+++ b/Sources/NiriMac/App/NiriMacApp.swift
@@ -11,21 +11,11 @@ final class NiriMacApp: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var focusDimMenuItem: NSMenuItem?
     private var autoFitMenuItem: NSMenuItem?
     private var excludedAppsMenuItem: NSMenuItem?
-    private var pendingMeta: NSEvent.ModifierFlags = [.control, .option]
-    private var pendingScrollLayout: NSEvent.ModifierFlags = [.option]
-    private var pendingScrollFocus: NSEvent.ModifierFlags = [.control, .option]
-    private var restartMenuItem: NSMenuItem?
-
     func applicationDidFinishLaunching(_ notification: Notification) {
         printDiagnostics()
-
-        let stored = ConfigStore.load()
-        pendingMeta = stored.meta
-        pendingScrollLayout = stored.scrollLayout
-        pendingScrollFocus = stored.scrollFocus
-
         setupStatusBar()
 
+        let stored = ConfigStore.load()
         var config = LayoutConfig()
         config.metaModifiers = stored.meta
         config.scrollLayoutModifiers = stored.scrollLayout
@@ -105,91 +95,17 @@ final class NiriMacApp: NSObject, NSApplicationDelegate, NSMenuDelegate {
         menu.addItem(reLayoutItem)
 
         menu.addItem(NSMenuItem.separator())
-        menu.addItem(makeModifierSubmenu(title: "Keyboard Meta", current: pendingMeta, tag: 1))
-        menu.addItem(makeModifierSubmenu(title: "Scroll: Layout", current: pendingScrollLayout, tag: 2))
-        menu.addItem(makeModifierSubmenu(title: "Scroll: Focus", current: pendingScrollFocus, tag: 3))
-
-        let restartItem = NSMenuItem(title: "Restart to Apply...", action: #selector(restartToApply), keyEquivalent: "")
-        restartItem.target = self
-        restartItem.isEnabled = false
-        self.restartMenuItem = restartItem
-        menu.addItem(restartItem)
+        let settingsItem = NSMenuItem(title: "Modifier Settings...", action: #selector(showModifierSettings), keyEquivalent: "")
+        settingsItem.target = self
+        menu.addItem(settingsItem)
 
         menu.addItem(NSMenuItem.separator())
         menu.addItem(withTitle: "Quit", action: #selector(quit), keyEquivalent: "q")
         statusItem?.menu = menu
     }
 
-    private func makeModifierSubmenu(title: String, current: NSEvent.ModifierFlags, tag: Int) -> NSMenuItem {
-        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
-        let submenu = NSMenu()
-        let pairs: [(String, NSEvent.ModifierFlags)] = [
-            ("Control (⌃)", .control),
-            ("Option (⌥)",  .option),
-            ("Command (⌘)", .command),
-            ("Shift (⇧)",   .shift),
-        ]
-        for (i, (label, flag)) in pairs.enumerated() {
-            let mi = NSMenuItem(title: label, action: #selector(toggleModifier(_:)), keyEquivalent: "")
-            mi.target = self
-            mi.state = current.contains(flag) ? .on : .off
-            mi.tag = tag * 10 + i
-            submenu.addItem(mi)
-        }
-        submenu.addItem(NSMenuItem.separator())
-        submenu.addItem(NSMenuItem(title: "(再起動後に反映)", action: nil, keyEquivalent: ""))
-        item.submenu = submenu
-        return item
-    }
-
-    private static let modifierFlagList: [NSEvent.ModifierFlags] = [.control, .option, .command, .shift]
-
-    @objc private func toggleModifier(_ sender: NSMenuItem) {
-        let group = sender.tag / 10
-        let flagIndex = sender.tag % 10
-        guard flagIndex < NiriMacApp.modifierFlagList.count else { return }
-        let flag = NiriMacApp.modifierFlagList[flagIndex]
-
-        switch group {
-        case 1:
-            if pendingMeta.contains(flag) { pendingMeta.remove(flag) } else { pendingMeta.insert(flag) }
-            if pendingMeta.isEmpty { pendingMeta.insert(flag); return }
-            sender.state = pendingMeta.contains(flag) ? .on : .off
-            if flag == .command && pendingMeta.contains(.command) {
-                let alert = NSAlert()
-                alert.messageText = "⚠️ Command をメタキーに含めると\nワークスペース操作が機能しなくなります"
-                alert.alertStyle = .warning
-                alert.addButton(withTitle: "OK")
-                alert.runModal()
-            }
-        case 2:
-            if pendingScrollLayout.contains(flag) { pendingScrollLayout.remove(flag) } else { pendingScrollLayout.insert(flag) }
-            if pendingScrollLayout.isEmpty { pendingScrollLayout.insert(flag); return }
-            sender.state = pendingScrollLayout.contains(flag) ? .on : .off
-        case 3:
-            if pendingScrollFocus.contains(flag) { pendingScrollFocus.remove(flag) } else { pendingScrollFocus.insert(flag) }
-            if pendingScrollFocus.isEmpty { pendingScrollFocus.insert(flag); return }
-            sender.state = pendingScrollFocus.contains(flag) ? .on : .off
-        default:
-            return
-        }
-
-        ConfigStore.save(meta: pendingMeta, scrollLayout: pendingScrollLayout, scrollFocus: pendingScrollFocus)
-        restartMenuItem?.isEnabled = true
-    }
-
-    @objc private func restartToApply() {
-        let alert = NSAlert()
-        alert.messageText = "再起動して設定変更を適用しますか？"
-        alert.addButton(withTitle: "再起動")
-        alert.addButton(withTitle: "キャンセル")
-        guard alert.runModal() == .alertFirstButtonReturn else { return }
-        let bundlePath = Bundle.main.bundlePath
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/bin/sh")
-        task.arguments = ["-c", "sleep 0.5; exec /usr/bin/open \"$1\"", "sh", bundlePath]
-        try? task.run()
-        NSApplication.shared.terminate(nil)
+    @objc private func showModifierSettings() {
+        ModifierSettingsWindowController.show()
     }
 
     /// メニューが開く直前にアクティブカラムの pin 状態を記録してタイトルを更新する

--- a/Sources/NiriMac/Bridge/ConfigStore.swift
+++ b/Sources/NiriMac/Bridge/ConfigStore.swift
@@ -1,0 +1,80 @@
+import AppKit
+import Foundation
+
+enum ConfigStore {
+    struct Config {
+        var meta: NSEvent.ModifierFlags
+        var scrollLayout: NSEvent.ModifierFlags
+        var scrollFocus: NSEvent.ModifierFlags
+    }
+
+    private struct Payload: Codable {
+        var metaModifiers: [String]
+        var scrollLayoutModifiers: [String]
+        var scrollFocusModifiers: [String]
+    }
+
+    static func load(from url: URL = defaultURL) -> Config {
+        guard let data = try? Data(contentsOf: url),
+              let payload = try? JSONDecoder().decode(Payload.self, from: data)
+        else {
+            return Config(
+                meta: [.control, .option],
+                scrollLayout: [.option],
+                scrollFocus: [.control, .option]
+            )
+        }
+        return Config(
+            meta: flags(from: payload.metaModifiers),
+            scrollLayout: flags(from: payload.scrollLayoutModifiers),
+            scrollFocus: flags(from: payload.scrollFocusModifiers)
+        )
+    }
+
+    static func save(
+        meta: NSEvent.ModifierFlags,
+        scrollLayout: NSEvent.ModifierFlags,
+        scrollFocus: NSEvent.ModifierFlags,
+        to url: URL = defaultURL
+    ) {
+        let dir = url.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let payload = Payload(
+                metaModifiers: strings(from: meta),
+                scrollLayoutModifiers: strings(from: scrollLayout),
+                scrollFocusModifiers: strings(from: scrollFocus)
+            )
+            let data = try JSONEncoder().encode(payload)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            print("[config] ⚠️ 設定ファイルの保存に失敗しました: \(error)")
+        }
+    }
+
+    static let defaultURL: URL = {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config")
+            .appendingPathComponent("niri-mac")
+            .appendingPathComponent("config.json")
+    }()
+
+    private static let modifierPairs: [(String, NSEvent.ModifierFlags)] = [
+        ("control", .control),
+        ("option",  .option),
+        ("command", .command),
+        ("shift",   .shift),
+    ]
+
+    static func strings(from flags: NSEvent.ModifierFlags) -> [String] {
+        modifierPairs.compactMap { name, flag in flags.contains(flag) ? name : nil }
+    }
+
+    static func flags(from strings: [String]) -> NSEvent.ModifierFlags {
+        strings.reduce(into: NSEvent.ModifierFlags()) { result, s in
+            if let pair = modifierPairs.first(where: { $0.0 == s }) {
+                result.insert(pair.1)
+            }
+        }
+    }
+}

--- a/Sources/NiriMac/Bridge/ConfigStore.swift
+++ b/Sources/NiriMac/Bridge/ConfigStore.swift
@@ -20,7 +20,7 @@ enum ConfigStore {
         else {
             return Config(
                 meta: [.control, .option],
-                scrollLayout: [.option],
+                scrollLayout: [.control],
                 scrollFocus: [.control, .option]
             )
         }

--- a/Sources/NiriMac/Bridge/KeyboardShortcutManager.swift
+++ b/Sources/NiriMac/Bridge/KeyboardShortcutManager.swift
@@ -56,42 +56,52 @@ final class KeyboardShortcutManager {
     private static let kReturn: UInt16 = 36
     private static let kQ:      UInt16 = 12
 
-    private let bindings: [Binding] = [
-        // カラム間フォーカス (Ctrl+Opt+Arrow: iTerm2/macOS両方と競合しにくい)
-        Binding(modifiers: [.control, .option], keyCode: 123, action: .focusLeft),
-        Binding(modifiers: [.control, .option], keyCode: 124, action: .focusRight),
-        // カラム内ウィンドウ
-        Binding(modifiers: [.control, .option], keyCode: 126, action: .focusUp),
-        Binding(modifiers: [.control, .option], keyCode: 125, action: .focusDown),
-        // カラム並べ替え
-        Binding(modifiers: [.control, .option, .shift], keyCode: 123, action: .moveColumnLeft),
-        Binding(modifiers: [.control, .option, .shift], keyCode: 124, action: .moveColumnRight),
-        // ワークスペース切り替え
-        Binding(modifiers: [.control, .option, .command], keyCode: 126, action: .switchWorkspaceUp),
-        Binding(modifiers: [.control, .option, .command], keyCode: 125, action: .switchWorkspaceDown),
-        // ウィンドウをワークスペース移動
-        Binding(modifiers: [.control, .option, .command, .shift], keyCode: 126, action: .moveWindowToWorkspaceUp),
-        Binding(modifiers: [.control, .option, .command, .shift], keyCode: 125, action: .moveWindowToWorkspaceDown),
-        // カラム操作
-        Binding(modifiers: [.control, .option], keyCode: 36, action: .consumeIntoColumnLeft),
-        Binding(modifiers: [.control, .option, .shift], keyCode: 36, action: .expelFromColumn),
-        // カラム幅サイクル
-        Binding(modifiers: [.control, .option], keyCode: 15, action: .cycleColumnWidth),
-        // カラムpin切り替え (Ctrl+Opt+P)
-        Binding(modifiers: [.control, .option], keyCode: 35, action: .togglePin),
-        // カラム内ウィンドウ並び替え (Ctrl+Opt+Shift+↑/↓)
-        Binding(modifiers: [.control, .option, .shift], keyCode: 126, action: .moveWindowUpInColumn),
-        Binding(modifiers: [.control, .option, .shift], keyCode: 125, action: .moveWindowDownInColumn),
-        // ウィンドウ高さリサイズ (Ctrl+Opt+- / Ctrl+Opt+=)
-        Binding(modifiers: [.control, .option], keyCode: 27, action: .shrinkWindowHeight),
-        Binding(modifiers: [.control, .option], keyCode: 24, action: .growWindowHeight),
-        // Auto-Fit ON/OFF (Ctrl+Opt+A)
-        Binding(modifiers: [.control, .option], keyCode: 0, action: .toggleAutoFit),
-        // 終了
-        Binding(modifiers: [.control, .option], keyCode: 12, action: .quit),
-        // Re-layout (Ctrl+Opt+Shift+F)
-        Binding(modifiers: [.control, .option, .shift], keyCode: 3, action: .reLayout),
-    ]
+    private let bindings: [Binding]
+
+    init(metaModifiers: NSEvent.ModifierFlags = [.control, .option]) {
+        self.bindings = KeyboardShortcutManager.buildBindings(meta: metaModifiers)
+    }
+
+    static func buildBindings(meta: NSEvent.ModifierFlags) -> [Binding] {
+        let metaShift    = meta.union([.shift])
+        let metaCmd      = meta.union([.command])
+        let metaCmdShift = meta.union([.command, .shift])
+        return [
+            // カラム間フォーカス
+            Binding(modifiers: meta,         keyCode: 123, action: .focusLeft),
+            Binding(modifiers: meta,         keyCode: 124, action: .focusRight),
+            // カラム内ウィンドウ
+            Binding(modifiers: meta,         keyCode: 126, action: .focusUp),
+            Binding(modifiers: meta,         keyCode: 125, action: .focusDown),
+            // カラム並べ替え
+            Binding(modifiers: metaShift,    keyCode: 123, action: .moveColumnLeft),
+            Binding(modifiers: metaShift,    keyCode: 124, action: .moveColumnRight),
+            // ワークスペース切り替え
+            Binding(modifiers: metaCmd,      keyCode: 126, action: .switchWorkspaceUp),
+            Binding(modifiers: metaCmd,      keyCode: 125, action: .switchWorkspaceDown),
+            // ウィンドウをワークスペース移動
+            Binding(modifiers: metaCmdShift, keyCode: 126, action: .moveWindowToWorkspaceUp),
+            Binding(modifiers: metaCmdShift, keyCode: 125, action: .moveWindowToWorkspaceDown),
+            // カラム操作
+            Binding(modifiers: meta,         keyCode: 36,  action: .consumeIntoColumnLeft),
+            Binding(modifiers: metaShift,    keyCode: 36,  action: .expelFromColumn),
+            // カラム幅・pin
+            Binding(modifiers: meta,         keyCode: 15,  action: .cycleColumnWidth),
+            Binding(modifiers: meta,         keyCode: 35,  action: .togglePin),
+            // カラム内ウィンドウ並び替え
+            Binding(modifiers: metaShift,    keyCode: 126, action: .moveWindowUpInColumn),
+            Binding(modifiers: metaShift,    keyCode: 125, action: .moveWindowDownInColumn),
+            // ウィンドウ高さリサイズ
+            Binding(modifiers: meta,         keyCode: 27,  action: .shrinkWindowHeight),
+            Binding(modifiers: meta,         keyCode: 24,  action: .growWindowHeight),
+            // Auto-Fit
+            Binding(modifiers: meta,         keyCode: 0,   action: .toggleAutoFit),
+            // 終了
+            Binding(modifiers: meta,         keyCode: 12,  action: .quit),
+            // Re-layout
+            Binding(modifiers: metaShift,    keyCode: 3,   action: .reLayout),
+        ]
+    }
 
     static func checkInputMonitoringPermission() -> Bool {
         return IOHIDCheckAccess(kIOHIDRequestTypeListenEvent) == kIOHIDAccessTypeGranted

--- a/Sources/NiriMac/Bridge/MouseEventManager.swift
+++ b/Sources/NiriMac/Bridge/MouseEventManager.swift
@@ -37,6 +37,9 @@ final class MouseEventManager {
     /// Cmd+Tab 等でアプリが切り替わった時
     var onAppActivated: (() -> Void)?
 
+    /// レイアウトスクロールをトリガーする修飾キー（一致したスクロールはアプリに転送しない）
+    var scrollLayoutModifiers: NSEvent.ModifierFlags = [.option]
+
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
     private var appSwitchObserver: Any?
@@ -153,10 +156,8 @@ final class MouseEventManager {
             if cgFlags.contains(.maskShift)     { flags.insert(.shift) }
             if cgFlags.contains(.maskControl)   { flags.insert(.control) }
 
-            // Option のみのスクロールは WM が処理するのでアプリへ転送しない
-            let suppress = cgFlags.contains(.maskAlternate)
-                        && !cgFlags.contains(.maskControl)
-                        && !cgFlags.contains(.maskCommand)
+            // scrollLayoutModifiers と一致するスクロールは WM が処理するのでアプリへ転送しない
+            let suppress = cgFlagsMatchModifiers(cgFlags, required: scrollLayoutModifiers)
 
             DispatchQueue.main.async { [weak self] in
                 self?.onScroll?(CGFloat(deltaX), CGFloat(deltaY), isContinuous, flags)
@@ -166,6 +167,17 @@ final class MouseEventManager {
         default:
             return false
         }
+    }
+
+    private func cgFlagsMatchModifiers(_ cgFlags: CGEventFlags, required: NSEvent.ModifierFlags) -> Bool {
+        var flags: NSEvent.ModifierFlags = []
+        if cgFlags.contains(.maskCommand)   { flags.insert(.command) }
+        if cgFlags.contains(.maskAlternate) { flags.insert(.option) }
+        if cgFlags.contains(.maskShift)     { flags.insert(.shift) }
+        if cgFlags.contains(.maskControl)   { flags.insert(.control) }
+        let filtered = flags.intersection([.command, .control, .option, .shift])
+        let requiredFiltered = required.intersection([.command, .control, .option, .shift])
+        return filtered == requiredFiltered
     }
 
     // MARK: - アプリ切り替え監視

--- a/Sources/NiriMac/Bridge/MouseEventManager.swift
+++ b/Sources/NiriMac/Bridge/MouseEventManager.swift
@@ -38,7 +38,7 @@ final class MouseEventManager {
     var onAppActivated: (() -> Void)?
 
     /// レイアウトスクロールをトリガーする修飾キー（一致したスクロールはアプリに転送しない）
-    var scrollLayoutModifiers: NSEvent.ModifierFlags = [.option]
+    var scrollLayoutModifiers: NSEvent.ModifierFlags = [.control]
 
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?

--- a/Sources/NiriMac/Engine/LayoutConfig.swift
+++ b/Sources/NiriMac/Engine/LayoutConfig.swift
@@ -73,7 +73,7 @@ struct LayoutConfig {
     var metaModifiers: NSEvent.ModifierFlags = [.control, .option]
 
     /// レイアウトスクロールのトリガー修飾キー
-    var scrollLayoutModifiers: NSEvent.ModifierFlags = [.option]
+    var scrollLayoutModifiers: NSEvent.ModifierFlags = [.control]
 
     /// カラムフォーカス移動スクロールのトリガー修飾キー
     var scrollFocusModifiers: NSEvent.ModifierFlags = [.control, .option]

--- a/Sources/NiriMac/Engine/LayoutConfig.swift
+++ b/Sources/NiriMac/Engine/LayoutConfig.swift
@@ -66,4 +66,15 @@ struct LayoutConfig {
 
     /// Auto-Fit で 1 カラム時のセンタリング幅（作業領域実効幅に対する比率）
     var autoFitCenterWidthFraction: CGFloat = 2.0 / 3.0
+
+    // MARK: - Modifier Keys
+
+    /// キーボードショートカットのベース修飾キー
+    var metaModifiers: NSEvent.ModifierFlags = [.control, .option]
+
+    /// レイアウトスクロールのトリガー修飾キー
+    var scrollLayoutModifiers: NSEvent.ModifierFlags = [.option]
+
+    /// カラムフォーカス移動スクロールのトリガー修飾キー
+    var scrollFocusModifiers: NSEvent.ModifierFlags = [.control, .option]
 }

--- a/Sources/NiriMac/Orchestrator/WindowManager.swift
+++ b/Sources/NiriMac/Orchestrator/WindowManager.swift
@@ -101,9 +101,10 @@ final class WindowManager {
     init(config: LayoutConfig = LayoutConfig()) {
         self.axBridge = AccessibilityBridge()
         self.observer = AXObserverBridge()
-        self.keyboard = KeyboardShortcutManager()
+        self.keyboard = KeyboardShortcutManager(metaModifiers: config.metaModifiers)
         self.mouse = MouseEventManager()
         self.config = config
+        self.mouse.scrollLayoutModifiers = config.scrollLayoutModifiers
     }
 
     // MARK: - Startup
@@ -1312,10 +1313,10 @@ final class WindowManager {
         let screenIdx = activeScreenIndex()
         guard screenIdx < screens.count else { return }
 
-        let filtered = flags.intersection([.control, .option])
+        let filtered = flags.intersection([.command, .control, .option, .shift])
 
-        // Ctrl+Opt+スクロール → カラムフォーカス移動
-        if filtered == [.control, .option] {
+        // scrollFocusModifiers+スクロール → カラムフォーカス移動
+        if filtered == config.scrollFocusModifiers {
             let now = Date()
             guard now.timeIntervalSince(lastScrollFocusTime) >= scrollFocusCooldown else { return }
             lastScrollFocusTime = now
@@ -1329,8 +1330,8 @@ final class WindowManager {
             return
         }
 
-        // Option + スクロール → レイアウトスクロール（縦横どちらも使える）
-        if filtered == [.option] {
+        // scrollLayoutModifiers + スクロール → レイアウトスクロール（縦横どちらも使える）
+        if filtered == config.scrollLayoutModifiers {
             let effective = abs(deltaX) >= abs(deltaY) ? deltaX : -deltaY
             guard abs(effective) > 0.5 else { return }
             applyLayoutScroll(effectiveDeltaX: effective, sensitivity: config.optionScrollSensitivity, isContinuous: isContinuous, screenIdx: screenIdx)

--- a/Tests/NiriMacTests/ConfigStoreTests.swift
+++ b/Tests/NiriMacTests/ConfigStoreTests.swift
@@ -1,0 +1,54 @@
+import Testing
+import Foundation
+import AppKit
+@testable import NiriMac
+
+@Suite("ConfigStore Tests")
+struct ConfigStoreTests {
+
+    private func makeTempURL() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("config.json")
+    }
+
+    @Test func loadReturnsDefaultsWhenFileNotFound() {
+        let url = makeTempURL()
+        let result = ConfigStore.load(from: url)
+        #expect(result.meta == [.control, .option])
+        #expect(result.scrollLayout == [.option])
+        #expect(result.scrollFocus == [.control, .option])
+    }
+
+    @Test func saveAndLoad() {
+        let url = makeTempURL()
+        ConfigStore.save(
+            meta: [.command, .option],
+            scrollLayout: [.control],
+            scrollFocus: [.command, .shift],
+            to: url
+        )
+        let result = ConfigStore.load(from: url)
+        #expect(result.meta == [.command, .option])
+        #expect(result.scrollLayout == [.control])
+        #expect(result.scrollFocus == [.command, .shift])
+    }
+
+    @Test func loadReturnsDefaultsWhenFileCorrupted() throws {
+        let url = makeTempURL()
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "not json".write(to: url, atomically: true, encoding: .utf8)
+        let result = ConfigStore.load(from: url)
+        #expect(result.meta == [.control, .option])
+    }
+
+    @Test func stringsFromFlagsRoundTrip() {
+        let flags: NSEvent.ModifierFlags = [.control, .option, .command]
+        let strings = ConfigStore.strings(from: flags)
+        let restored = ConfigStore.flags(from: strings)
+        #expect(restored == flags)
+    }
+}

--- a/Tests/NiriMacTests/ConfigStoreTests.swift
+++ b/Tests/NiriMacTests/ConfigStoreTests.swift
@@ -16,7 +16,7 @@ struct ConfigStoreTests {
         let url = makeTempURL()
         let result = ConfigStore.load(from: url)
         #expect(result.meta == [.control, .option])
-        #expect(result.scrollLayout == [.option])
+        #expect(result.scrollLayout == [.control])
         #expect(result.scrollFocus == [.control, .option])
     }
 

--- a/Tests/NiriMacTests/KeyboardShortcutManagerTests.swift
+++ b/Tests/NiriMacTests/KeyboardShortcutManagerTests.swift
@@ -1,0 +1,36 @@
+import Testing
+import AppKit
+@testable import NiriMac
+
+@Suite("KeyboardShortcutManager Binding Tests")
+struct KeyboardShortcutManagerTests {
+
+    @Test func defaultMetaGenerates21Bindings() {
+        let bindings = KeyboardShortcutManager.buildBindings(meta: [.control, .option])
+        #expect(bindings.count == 21)
+    }
+
+    @Test func focusLeftUsesMetaModifiers() {
+        let bindings = KeyboardShortcutManager.buildBindings(meta: [.command, .option])
+        let b = bindings.first { $0.action == .focusLeft }
+        #expect(b?.modifiers == [.command, .option])
+    }
+
+    @Test func moveColumnLeftUsesMetaPlusShift() {
+        let bindings = KeyboardShortcutManager.buildBindings(meta: [.command, .option])
+        let b = bindings.first { $0.action == .moveColumnLeft }
+        #expect(b?.modifiers == [.command, .option, .shift])
+    }
+
+    @Test func switchWorkspaceUpUsesMetaPlusCommand() {
+        let bindings = KeyboardShortcutManager.buildBindings(meta: [.control, .option])
+        let b = bindings.first { $0.action == .switchWorkspaceUp }
+        #expect(b?.modifiers == [.control, .option, .command])
+    }
+
+    @Test func moveWindowToWorkspaceUsesMetaPlusCommandShift() {
+        let bindings = KeyboardShortcutManager.buildBindings(meta: [.control, .option])
+        let b = bindings.first { $0.action == .moveWindowToWorkspaceUp }
+        #expect(b?.modifiers == [.control, .option, .command, .shift])
+    }
+}

--- a/Tests/NiriMacTests/ModifierSettingsModelTests.swift
+++ b/Tests/NiriMacTests/ModifierSettingsModelTests.swift
@@ -1,0 +1,60 @@
+import Testing
+import AppKit
+@testable import NiriMac
+
+@Suite("ModifierSettingsModel Tests")
+struct ModifierSettingsModelTests {
+
+    @Test func currentMetaReflectsToggles() {
+        let model = ModifierSettingsModel(
+            meta: [.control, .option],
+            scrollLayout: [.control],
+            scrollFocus: [.control, .option]
+        )
+        #expect(model.currentMeta == [.control, .option])
+        model.metaCommand = true
+        #expect(model.currentMeta == [.control, .option, .command])
+    }
+
+    @Test func hasChangesWhenMetaDiffers() {
+        let model = ModifierSettingsModel(
+            meta: [.control, .option],
+            scrollLayout: [.control],
+            scrollFocus: [.control, .option]
+        )
+        #expect(model.hasChanges == false)
+        model.metaShift = true
+        #expect(model.hasChanges == true)
+    }
+
+    @Test func hasChangesWhenScrollLayoutDiffers() {
+        let model = ModifierSettingsModel(
+            meta: [.control, .option],
+            scrollLayout: [.control],
+            scrollFocus: [.control, .option]
+        )
+        model.layoutOption = true
+        #expect(model.hasChanges == true)
+    }
+
+    @Test func anyEmptyWhenMetaAllUnchecked() {
+        let model = ModifierSettingsModel(
+            meta: [.control],
+            scrollLayout: [.control],
+            scrollFocus: [.control, .option]
+        )
+        model.metaControl = false
+        #expect(model.anyEmpty == true)
+    }
+
+    @Test func metaHasCommandReflectsState() {
+        let model = ModifierSettingsModel(
+            meta: [.control, .option],
+            scrollLayout: [.control],
+            scrollFocus: [.control, .option]
+        )
+        #expect(model.metaHasCommand == false)
+        model.metaCommand = true
+        #expect(model.metaHasCommand == true)
+    }
+}

--- a/docs/superpowers/plans/2026-04-25-meta-key-config.md
+++ b/docs/superpowers/plans/2026-04-25-meta-key-config.md
@@ -1,0 +1,757 @@
+# Meta Key & Scroll Modifier Configuration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** キーボードショートカットとスクロールのベース修飾キーをステータスバーメニューから自由に変更し、`~/.config/niri-mac/config.json` に永続化する。
+
+**Architecture:** `LayoutConfig` に3つの `NSEvent.ModifierFlags` フィールドを追加。`ConfigStore`（新規）で JSON 永続化。`KeyboardShortcutManager` は `init` 時に `metaModifiers` を受け取り動的バインディング生成。`MouseEventManager` の suppress ロジックと `WindowManager` のスクロールハンドラを config から読む。ステータスバーに3つの修飾キーサブメニューと「Restart to Apply...」を追加。
+
+**Tech Stack:** Swift 5.9, AppKit, swift-testing (`@Suite`, `@Test`, `#expect`), `swift test --filter`
+
+---
+
+## File Map
+
+| ファイル | 変更種別 |
+|----------|----------|
+| `Sources/NiriMac/Engine/LayoutConfig.swift` | 変更 — 3フィールド追加 |
+| `Sources/NiriMac/Bridge/ConfigStore.swift` | **新規** — JSON load/save |
+| `Sources/NiriMac/Bridge/KeyboardShortcutManager.swift` | 変更 — init + 動的バインディング |
+| `Sources/NiriMac/Bridge/MouseEventManager.swift` | 変更 — suppress 動的化 |
+| `Sources/NiriMac/Orchestrator/WindowManager.swift` | 変更 — scroll handler + init wiring |
+| `Sources/NiriMac/App/NiriMacApp.swift` | 変更 — ConfigStore 読み込み + メニュー |
+| `Tests/NiriMacTests/ConfigStoreTests.swift` | **新規** — load/save/roundtrip テスト |
+| `Tests/NiriMacTests/KeyboardShortcutManagerTests.swift` | **新規** — 動的バインディングテスト |
+
+---
+
+### Task 1: LayoutConfig — modifier フィールド追加
+
+**Files:**
+- Modify: `Sources/NiriMac/Engine/LayoutConfig.swift`
+
+- [ ] **Step 1: autoFitCenterWidthFraction の後に MARK と3フィールドを追加**
+
+`Sources/NiriMac/Engine/LayoutConfig.swift` の末尾（`}` の直前）に追加:
+
+```swift
+    // MARK: - Modifier Keys
+
+    /// キーボードショートカットのベース修飾キー
+    var metaModifiers: NSEvent.ModifierFlags = [.control, .option]
+
+    /// レイアウトスクロールのトリガー修飾キー
+    var scrollLayoutModifiers: NSEvent.ModifierFlags = [.option]
+
+    /// カラムフォーカス移動スクロールのトリガー修飾キー
+    var scrollFocusModifiers: NSEvent.ModifierFlags = [.control, .option]
+```
+
+- [ ] **Step 2: ビルド確認**
+
+```bash
+swift build 2>&1 | tail -5
+```
+
+Expected: `Build complete!`
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add Sources/NiriMac/Engine/LayoutConfig.swift
+git commit -m "feat: add metaModifiers/scrollLayoutModifiers/scrollFocusModifiers to LayoutConfig"
+```
+
+---
+
+### Task 2: ConfigStore — JSON 永続化 (TDD)
+
+**Files:**
+- Create: `Sources/NiriMac/Bridge/ConfigStore.swift`
+- Create: `Tests/NiriMacTests/ConfigStoreTests.swift`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`Tests/NiriMacTests/ConfigStoreTests.swift` を新規作成:
+
+```swift
+import Testing
+import Foundation
+import AppKit
+@testable import NiriMac
+
+@Suite("ConfigStore Tests")
+struct ConfigStoreTests {
+
+    private func makeTempURL() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("config.json")
+    }
+
+    @Test func loadReturnsDefaultsWhenFileNotFound() {
+        let url = makeTempURL()
+        let result = ConfigStore.load(from: url)
+        #expect(result.meta == [.control, .option])
+        #expect(result.scrollLayout == [.option])
+        #expect(result.scrollFocus == [.control, .option])
+    }
+
+    @Test func saveAndLoad() {
+        let url = makeTempURL()
+        ConfigStore.save(
+            meta: [.command, .option],
+            scrollLayout: [.control],
+            scrollFocus: [.command, .shift],
+            to: url
+        )
+        let result = ConfigStore.load(from: url)
+        #expect(result.meta == [.command, .option])
+        #expect(result.scrollLayout == [.control])
+        #expect(result.scrollFocus == [.command, .shift])
+    }
+
+    @Test func loadReturnsDefaultsWhenFileCorrupted() throws {
+        let url = makeTempURL()
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "not json".write(to: url, atomically: true, encoding: .utf8)
+        let result = ConfigStore.load(from: url)
+        #expect(result.meta == [.control, .option])
+    }
+
+    @Test func stringsFromFlagsRoundTrip() {
+        let flags: NSEvent.ModifierFlags = [.control, .option, .command]
+        let strings = ConfigStore.strings(from: flags)
+        let restored = ConfigStore.flags(from: strings)
+        #expect(restored == flags)
+    }
+}
+```
+
+- [ ] **Step 2: テストがコンパイルエラーで失敗することを確認**
+
+```bash
+swift test --filter ConfigStoreTests 2>&1 | tail -10
+```
+
+Expected: `error: cannot find type 'ConfigStore'`
+
+- [ ] **Step 3: ConfigStore.swift を作成**
+
+`Sources/NiriMac/Bridge/ConfigStore.swift` を新規作成:
+
+```swift
+import AppKit
+import Foundation
+
+enum ConfigStore {
+    struct Config {
+        var meta: NSEvent.ModifierFlags
+        var scrollLayout: NSEvent.ModifierFlags
+        var scrollFocus: NSEvent.ModifierFlags
+    }
+
+    private struct Payload: Codable {
+        var metaModifiers: [String]
+        var scrollLayoutModifiers: [String]
+        var scrollFocusModifiers: [String]
+    }
+
+    static func load(from url: URL = defaultURL) -> Config {
+        guard let data = try? Data(contentsOf: url),
+              let payload = try? JSONDecoder().decode(Payload.self, from: data)
+        else {
+            return Config(
+                meta: [.control, .option],
+                scrollLayout: [.option],
+                scrollFocus: [.control, .option]
+            )
+        }
+        return Config(
+            meta: flags(from: payload.metaModifiers),
+            scrollLayout: flags(from: payload.scrollLayoutModifiers),
+            scrollFocus: flags(from: payload.scrollFocusModifiers)
+        )
+    }
+
+    static func save(
+        meta: NSEvent.ModifierFlags,
+        scrollLayout: NSEvent.ModifierFlags,
+        scrollFocus: NSEvent.ModifierFlags,
+        to url: URL = defaultURL
+    ) {
+        let dir = url.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let payload = Payload(
+                metaModifiers: strings(from: meta),
+                scrollLayoutModifiers: strings(from: scrollLayout),
+                scrollFocusModifiers: strings(from: scrollFocus)
+            )
+            let data = try JSONEncoder().encode(payload)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            print("[config] ⚠️ 設定ファイルの保存に失敗しました: \(error)")
+        }
+    }
+
+    static let defaultURL: URL = {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config")
+            .appendingPathComponent("niri-mac")
+            .appendingPathComponent("config.json")
+    }()
+
+    private static let modifierPairs: [(String, NSEvent.ModifierFlags)] = [
+        ("control", .control),
+        ("option",  .option),
+        ("command", .command),
+        ("shift",   .shift),
+    ]
+
+    static func strings(from flags: NSEvent.ModifierFlags) -> [String] {
+        modifierPairs.compactMap { name, flag in flags.contains(flag) ? name : nil }
+    }
+
+    static func flags(from strings: [String]) -> NSEvent.ModifierFlags {
+        strings.reduce(into: NSEvent.ModifierFlags()) { result, s in
+            if let pair = modifierPairs.first(where: { $0.0 == s }) {
+                result.insert(pair.1)
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: テストがパスすることを確認**
+
+```bash
+swift test --filter ConfigStoreTests 2>&1 | tail -10
+```
+
+Expected: `Test run with 4 tests passed.`
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add Sources/NiriMac/Bridge/ConfigStore.swift Tests/NiriMacTests/ConfigStoreTests.swift
+git commit -m "feat: add ConfigStore for modifier key JSON persistence"
+```
+
+---
+
+### Task 3: KeyboardShortcutManager — 動的バインディング生成 (TDD)
+
+**Files:**
+- Modify: `Sources/NiriMac/Bridge/KeyboardShortcutManager.swift`
+- Create: `Tests/NiriMacTests/KeyboardShortcutManagerTests.swift`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`Tests/NiriMacTests/KeyboardShortcutManagerTests.swift` を新規作成:
+
+```swift
+import Testing
+import AppKit
+@testable import NiriMac
+
+@Suite("KeyboardShortcutManager Binding Tests")
+struct KeyboardShortcutManagerTests {
+
+    @Test func defaultMetaGenerates21Bindings() {
+        let bindings = KeyboardShortcutManager.buildBindings(meta: [.control, .option])
+        #expect(bindings.count == 21)
+    }
+
+    @Test func focusLeftUsesMetaModifiers() {
+        let bindings = KeyboardShortcutManager.buildBindings(meta: [.command, .option])
+        let b = bindings.first { $0.action == .focusLeft }
+        #expect(b?.modifiers == [.command, .option])
+    }
+
+    @Test func moveColumnLeftUsesMetaPlusShift() {
+        let bindings = KeyboardShortcutManager.buildBindings(meta: [.command, .option])
+        let b = bindings.first { $0.action == .moveColumnLeft }
+        #expect(b?.modifiers == [.command, .option, .shift])
+    }
+
+    @Test func switchWorkspaceUpUsesMetaPlusCommand() {
+        let bindings = KeyboardShortcutManager.buildBindings(meta: [.control, .option])
+        let b = bindings.first { $0.action == .switchWorkspaceUp }
+        #expect(b?.modifiers == [.control, .option, .command])
+    }
+
+    @Test func moveWindowToWorkspaceUsesMetaPlusCommandShift() {
+        let bindings = KeyboardShortcutManager.buildBindings(meta: [.control, .option])
+        let b = bindings.first { $0.action == .moveWindowToWorkspaceUp }
+        #expect(b?.modifiers == [.control, .option, .command, .shift])
+    }
+}
+```
+
+- [ ] **Step 2: テストがコンパイルエラーで失敗することを確認**
+
+```bash
+swift test --filter KeyboardShortcutManagerTests 2>&1 | tail -10
+```
+
+Expected: `error: type 'KeyboardShortcutManager' has no member 'buildBindings'`
+
+- [ ] **Step 3: KeyboardShortcutManager を変更**
+
+`Sources/NiriMac/Bridge/KeyboardShortcutManager.swift` の以下の箇所を変更する。
+
+**3a. `private let bindings: [Binding] = [...]` ブロック全体を削除し、以下で置き換える:**
+
+```swift
+    private let bindings: [Binding]
+
+    init(metaModifiers: NSEvent.ModifierFlags = [.control, .option]) {
+        self.bindings = KeyboardShortcutManager.buildBindings(meta: metaModifiers)
+    }
+
+    static func buildBindings(meta: NSEvent.ModifierFlags) -> [Binding] {
+        let metaShift    = meta.union([.shift])
+        let metaCmd      = meta.union([.command])
+        let metaCmdShift = meta.union([.command, .shift])
+        return [
+            // カラム間フォーカス
+            Binding(modifiers: meta,         keyCode: 123, action: .focusLeft),
+            Binding(modifiers: meta,         keyCode: 124, action: .focusRight),
+            // カラム内ウィンドウ
+            Binding(modifiers: meta,         keyCode: 126, action: .focusUp),
+            Binding(modifiers: meta,         keyCode: 125, action: .focusDown),
+            // カラム並べ替え
+            Binding(modifiers: metaShift,    keyCode: 123, action: .moveColumnLeft),
+            Binding(modifiers: metaShift,    keyCode: 124, action: .moveColumnRight),
+            // ワークスペース切り替え
+            Binding(modifiers: metaCmd,      keyCode: 126, action: .switchWorkspaceUp),
+            Binding(modifiers: metaCmd,      keyCode: 125, action: .switchWorkspaceDown),
+            // ウィンドウをワークスペース移動
+            Binding(modifiers: metaCmdShift, keyCode: 126, action: .moveWindowToWorkspaceUp),
+            Binding(modifiers: metaCmdShift, keyCode: 125, action: .moveWindowToWorkspaceDown),
+            // カラム操作
+            Binding(modifiers: meta,         keyCode: 36,  action: .consumeIntoColumnLeft),
+            Binding(modifiers: metaShift,    keyCode: 36,  action: .expelFromColumn),
+            // カラム幅・pin
+            Binding(modifiers: meta,         keyCode: 15,  action: .cycleColumnWidth),
+            Binding(modifiers: meta,         keyCode: 35,  action: .togglePin),
+            // カラム内ウィンドウ並び替え
+            Binding(modifiers: metaShift,    keyCode: 126, action: .moveWindowUpInColumn),
+            Binding(modifiers: metaShift,    keyCode: 125, action: .moveWindowDownInColumn),
+            // ウィンドウ高さリサイズ
+            Binding(modifiers: meta,         keyCode: 27,  action: .shrinkWindowHeight),
+            Binding(modifiers: meta,         keyCode: 24,  action: .growWindowHeight),
+            // Auto-Fit
+            Binding(modifiers: meta,         keyCode: 0,   action: .toggleAutoFit),
+            // 終了
+            Binding(modifiers: meta,         keyCode: 12,  action: .quit),
+            // Re-layout
+            Binding(modifiers: metaShift,    keyCode: 3,   action: .reLayout),
+        ]
+    }
+```
+
+- [ ] **Step 4: テストがパスすることを確認**
+
+```bash
+swift test --filter KeyboardShortcutManagerTests 2>&1 | tail -10
+```
+
+Expected: `Test run with 5 tests passed.`
+
+- [ ] **Step 5: 全テストが通ることを確認**
+
+```bash
+swift test 2>&1 | tail -5
+```
+
+Expected: 全テスト pass
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add Sources/NiriMac/Bridge/KeyboardShortcutManager.swift Tests/NiriMacTests/KeyboardShortcutManagerTests.swift
+git commit -m "feat: generate keyboard bindings dynamically from metaModifiers"
+```
+
+---
+
+### Task 4: MouseEventManager — suppress ロジック動的化
+
+**Files:**
+- Modify: `Sources/NiriMac/Bridge/MouseEventManager.swift`
+
+- [ ] **Step 1: scrollLayoutModifiers プロパティを追加**
+
+`Sources/NiriMac/Bridge/MouseEventManager.swift` の `var onAppActivated` 宣言の直後に追加:
+
+```swift
+    /// レイアウトスクロールをトリガーする修飾キー（一致したスクロールはアプリに転送しない）
+    var scrollLayoutModifiers: NSEvent.ModifierFlags = [.option]
+```
+
+- [ ] **Step 2: suppress ロジックを置き換える**
+
+`handleCGEvent` 内の suppress 行（現在の以下のブロック）を:
+
+```swift
+            // Option のみのスクロールは WM が処理するのでアプリへ転送しない
+            let suppress = cgFlags.contains(.maskAlternate)
+                        && !cgFlags.contains(.maskControl)
+                        && !cgFlags.contains(.maskCommand)
+```
+
+以下に置き換える:
+
+```swift
+            // scrollLayoutModifiers と一致するスクロールは WM が処理するのでアプリへ転送しない
+            let suppress = cgFlagsMatchModifiers(cgFlags, required: scrollLayoutModifiers)
+```
+
+- [ ] **Step 3: ヘルパーメソッドを追加**
+
+`MouseEventManager` クラスの末尾（`}` の直前）に追加:
+
+```swift
+    private func cgFlagsMatchModifiers(_ cgFlags: CGEventFlags, required: NSEvent.ModifierFlags) -> Bool {
+        var flags: NSEvent.ModifierFlags = []
+        if cgFlags.contains(.maskCommand)   { flags.insert(.command) }
+        if cgFlags.contains(.maskAlternate) { flags.insert(.option) }
+        if cgFlags.contains(.maskShift)     { flags.insert(.shift) }
+        if cgFlags.contains(.maskControl)   { flags.insert(.control) }
+        let filtered = flags.intersection([.command, .control, .option, .shift])
+        let requiredFiltered = required.intersection([.command, .control, .option, .shift])
+        return filtered == requiredFiltered
+    }
+```
+
+- [ ] **Step 4: ビルドと全テスト確認**
+
+```bash
+swift build 2>&1 | tail -5 && swift test 2>&1 | tail -5
+```
+
+Expected: `Build complete!` → 全テスト pass
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add Sources/NiriMac/Bridge/MouseEventManager.swift
+git commit -m "feat: make MouseEventManager suppress logic dynamic via scrollLayoutModifiers"
+```
+
+---
+
+### Task 5: WindowManager — scroll handler + init wiring
+
+**Files:**
+- Modify: `Sources/NiriMac/Orchestrator/WindowManager.swift`
+
+- [ ] **Step 1: init の keyboard/mouse 初期化を更新（101〜106行付近）**
+
+現在:
+```swift
+    init(config: LayoutConfig = LayoutConfig()) {
+        self.axBridge = AccessibilityBridge()
+        self.observer = AXObserverBridge()
+        self.keyboard = KeyboardShortcutManager()
+        self.mouse = MouseEventManager()
+        self.config = config
+    }
+```
+
+以下に変更:
+```swift
+    init(config: LayoutConfig = LayoutConfig()) {
+        self.axBridge = AccessibilityBridge()
+        self.observer = AXObserverBridge()
+        self.keyboard = KeyboardShortcutManager(metaModifiers: config.metaModifiers)
+        self.mouse = MouseEventManager()
+        self.config = config
+        self.mouse.scrollLayoutModifiers = config.scrollLayoutModifiers
+    }
+```
+
+- [ ] **Step 2: handleScroll の modifier フィルタを更新（1315行付近）**
+
+現在:
+```swift
+        let filtered = flags.intersection([.control, .option])
+```
+
+以下に変更:
+```swift
+        let filtered = flags.intersection([.command, .control, .option, .shift])
+```
+
+- [ ] **Step 3: handleScroll の修飾キー比較を置き換える（1318行・1333行付近）**
+
+現在:
+```swift
+        // Ctrl+Opt+スクロール → カラムフォーカス移動
+        if filtered == [.control, .option] {
+```
+
+以下に変更:
+```swift
+        // scrollFocusModifiers+スクロール → カラムフォーカス移動
+        if filtered == config.scrollFocusModifiers {
+```
+
+現在:
+```swift
+        // Option + スクロール → レイアウトスクロール（縦横どちらも使える）
+        if filtered == [.option] {
+```
+
+以下に変更:
+```swift
+        // scrollLayoutModifiers + スクロール → レイアウトスクロール（縦横どちらも使える）
+        if filtered == config.scrollLayoutModifiers {
+```
+
+- [ ] **Step 4: ビルドと全テスト確認**
+
+```bash
+swift build 2>&1 | tail -5 && swift test 2>&1 | tail -5
+```
+
+Expected: `Build complete!` → 全テスト pass
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add Sources/NiriMac/Orchestrator/WindowManager.swift
+git commit -m "feat: wire metaModifiers/scrollModifiers from config into managers"
+```
+
+---
+
+### Task 6: NiriMacApp — ConfigStore 読み込み + 修飾キーメニュー
+
+**Files:**
+- Modify: `Sources/NiriMac/App/NiriMacApp.swift`
+
+- [ ] **Step 1: プロパティを追加**
+
+`NiriMacApp` クラスの既存プロパティ（`autoFitMenuItem` 等）の直後に追加:
+
+```swift
+    private var pendingMeta: NSEvent.ModifierFlags = [.control, .option]
+    private var pendingScrollLayout: NSEvent.ModifierFlags = [.option]
+    private var pendingScrollFocus: NSEvent.ModifierFlags = [.control, .option]
+    private var modifierChangePending = false
+    private var restartMenuItem: NSMenuItem?
+```
+
+- [ ] **Step 2: applicationDidFinishLaunching を更新**
+
+現在:
+```swift
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        printDiagnostics()
+        setupStatusBar()
+
+        let config = LayoutConfig()
+        windowManager = WindowManager(config: config)
+        windowManager?.start()
+    }
+```
+
+以下に変更:
+```swift
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        printDiagnostics()
+
+        let stored = ConfigStore.load()
+        pendingMeta = stored.meta
+        pendingScrollLayout = stored.scrollLayout
+        pendingScrollFocus = stored.scrollFocus
+
+        setupStatusBar()
+
+        var config = LayoutConfig()
+        config.metaModifiers = stored.meta
+        config.scrollLayoutModifiers = stored.scrollLayout
+        config.scrollFocusModifiers = stored.scrollFocus
+        windowManager = WindowManager(config: config)
+        windowManager?.start()
+    }
+```
+
+- [ ] **Step 3: makeModifierSubmenu ヘルパーを追加**
+
+`NiriMacApp` に以下のメソッドを追加:
+
+```swift
+    private func makeModifierSubmenu(title: String, current: NSEvent.ModifierFlags, tag: Int) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        let submenu = NSMenu()
+        let pairs: [(String, NSEvent.ModifierFlags)] = [
+            ("Control (⌃)", .control),
+            ("Option (⌥)",  .option),
+            ("Command (⌘)", .command),
+            ("Shift (⇧)",   .shift),
+        ]
+        for (i, (label, flag)) in pairs.enumerated() {
+            let mi = NSMenuItem(title: label, action: #selector(toggleModifier(_:)), keyEquivalent: "")
+            mi.target = self
+            mi.state = current.contains(flag) ? .on : .off
+            mi.tag = tag * 10 + i
+            submenu.addItem(mi)
+        }
+        submenu.addItem(NSMenuItem.separator())
+        submenu.addItem(NSMenuItem(title: "(再起動後に反映)", action: nil, keyEquivalent: ""))
+        item.submenu = submenu
+        return item
+    }
+```
+
+- [ ] **Step 4: toggleModifier アクションを追加**
+
+```swift
+    private static let modifierFlagList: [NSEvent.ModifierFlags] = [.control, .option, .command, .shift]
+
+    @objc private func toggleModifier(_ sender: NSMenuItem) {
+        let group = sender.tag / 10
+        let flagIndex = sender.tag % 10
+        guard flagIndex < NiriMacApp.modifierFlagList.count else { return }
+        let flag = NiriMacApp.modifierFlagList[flagIndex]
+
+        switch group {
+        case 1:
+            if pendingMeta.contains(flag) { pendingMeta.remove(flag) } else { pendingMeta.insert(flag) }
+            if pendingMeta.isEmpty { pendingMeta.insert(flag); return }
+            sender.state = pendingMeta.contains(flag) ? .on : .off
+            if pendingMeta.contains(.command) {
+                let alert = NSAlert()
+                alert.messageText = "⚠️ Command をメタキーに含めると\nワークスペース操作が機能しなくなります"
+                alert.alertStyle = .warning
+                alert.addButton(withTitle: "OK")
+                alert.runModal()
+            }
+        case 2:
+            if pendingScrollLayout.contains(flag) { pendingScrollLayout.remove(flag) } else { pendingScrollLayout.insert(flag) }
+            if pendingScrollLayout.isEmpty { pendingScrollLayout.insert(flag); return }
+            sender.state = pendingScrollLayout.contains(flag) ? .on : .off
+        case 3:
+            if pendingScrollFocus.contains(flag) { pendingScrollFocus.remove(flag) } else { pendingScrollFocus.insert(flag) }
+            if pendingScrollFocus.isEmpty { pendingScrollFocus.insert(flag); return }
+            sender.state = pendingScrollFocus.contains(flag) ? .on : .off
+        default:
+            return
+        }
+
+        ConfigStore.save(meta: pendingMeta, scrollLayout: pendingScrollLayout, scrollFocus: pendingScrollFocus)
+        modifierChangePending = true
+        restartMenuItem?.isEnabled = true
+    }
+```
+
+- [ ] **Step 5: restartToApply アクションを追加**
+
+```swift
+    @objc private func restartToApply() {
+        let alert = NSAlert()
+        alert.messageText = "再起動して設定変更を適用しますか？"
+        alert.addButton(withTitle: "再起動")
+        alert.addButton(withTitle: "キャンセル")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let bundlePath = Bundle.main.bundlePath
+        let task = Process()
+        task.launchPath = "/bin/sh"
+        task.arguments = ["-c", "sleep 0.5; open '\(bundlePath)'"]
+        try? task.run()
+        NSApplication.shared.terminate(nil)
+    }
+```
+
+- [ ] **Step 6: setupStatusBar にサブメニューと Restart を追加**
+
+`setupStatusBar()` 内、`reLayoutItem` の `menu.addItem(reLayoutItem)` の直後・`menu.addItem(NSMenuItem.separator())` の前に挿入:
+
+```swift
+        menu.addItem(reLayoutItem)  // ← 既存行（この直後に追記）
+
+        menu.addItem(NSMenuItem.separator())
+        menu.addItem(makeModifierSubmenu(title: "Keyboard Meta", current: pendingMeta, tag: 1))
+        menu.addItem(makeModifierSubmenu(title: "Scroll: Layout", current: pendingScrollLayout, tag: 2))
+        menu.addItem(makeModifierSubmenu(title: "Scroll: Focus", current: pendingScrollFocus, tag: 3))
+
+        let restartItem = NSMenuItem(title: "Restart to Apply...", action: #selector(restartToApply), keyEquivalent: "")
+        restartItem.target = self
+        restartItem.isEnabled = false
+        self.restartMenuItem = restartItem
+        menu.addItem(restartItem)
+        // ↓ 既存の separator + Quit がこの後に続く
+```
+
+- [ ] **Step 7: ビルドと全テスト確認**
+
+```bash
+swift build 2>&1 | tail -10
+swift test 2>&1 | tail -5
+```
+
+Expected: `Build complete!` → 全テスト pass
+
+- [ ] **Step 8: コミット**
+
+```bash
+git add Sources/NiriMac/App/NiriMacApp.swift
+git commit -m "feat: add modifier key config menu and restart-to-apply to status bar"
+```
+
+---
+
+### Task 7: 手動動作確認
+
+**Files:** なし（動作確認のみ）
+
+- [ ] **Step 1: アプリバンドルをビルド**
+
+```bash
+bash make-app.sh
+open NiriMac.app
+```
+
+- [ ] **Step 2: 初期状態の確認**
+
+ステータスバー → 以下を確認:
+- 「Keyboard Meta」サブメニュー → Control・Option がチェック済み
+- 「Scroll: Layout」サブメニュー → Option のみチェック済み
+- 「Scroll: Focus」サブメニュー → Control・Option がチェック済み
+- 「Restart to Apply...」がグレーアウト
+
+- [ ] **Step 3: メタキー変更とリスタートフロー**
+
+1. 「Keyboard Meta」→ Control のチェックを外す
+2. 「Restart to Apply...」が有効になることを確認
+3. クリック → 確認ダイアログ → 「再起動」
+4. 再起動後、ステータスバー → 「Keyboard Meta」→ Control がチェックなしのまま（永続化確認）
+
+- [ ] **Step 4: 新しいメタキーで動作確認**
+
+（Meta = Option のみに設定した場合）
+- `Option + ←` → カラムフォーカス左移動
+- `Option + →` → カラムフォーカス右移動
+- `Option + Shift + ←` → カラム左並べ替え
+
+- [ ] **Step 5: 設定ファイル確認**
+
+```bash
+cat ~/.config/niri-mac/config.json
+```
+
+Expected（例）:
+```json
+{
+  "metaModifiers": ["option"],
+  "scrollLayoutModifiers": ["option"],
+  "scrollFocusModifiers": ["option"]
+}
+```

--- a/docs/superpowers/plans/2026-04-26-modifier-settings-window.md
+++ b/docs/superpowers/plans/2026-04-26-modifier-settings-window.md
@@ -1,0 +1,526 @@
+# Modifier Settings Window Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** ステータスバーの入れ子メニューを廃止し、SwiftUI + NSPanel による設定ウィンドウで modifier キーを設定できるようにする。
+
+**Architecture:** `ModifierSettingsModel`（ObservableObject）で状態管理、`ModifierSettingsView`（SwiftUI Form）で UI、`ModifierSettingsWindowController`（NSWindowController）がシングルトンで NSPanel を管理。`NiriMacApp` はサブメニュー群を削除し「Modifier Settings...」の 1 項目に置き換える。
+
+**Tech Stack:** Swift 5.9, AppKit, SwiftUI（NSHostingController 経由で埋め込み）, swift-testing
+
+---
+
+## File Map
+
+| ファイル | 変更種別 |
+|----------|----------|
+| `Sources/NiriMac/App/ModifierSettingsView.swift` | **新規** — SwiftUI View + ObservableObject Model |
+| `Sources/NiriMac/App/ModifierSettingsWindowController.swift` | **新規** — NSWindowController（シングルトン NSPanel）|
+| `Sources/NiriMac/App/NiriMacApp.swift` | 変更 — サブメニュー削除、"Modifier Settings..." 追加 |
+| `Tests/NiriMacTests/ModifierSettingsModelTests.swift` | **新規** — Model のユニットテスト |
+
+---
+
+### Task 1: ModifierSettingsModel + ModifierSettingsView (TDD)
+
+**Files:**
+- Create: `Sources/NiriMac/App/ModifierSettingsView.swift`
+- Create: `Tests/NiriMacTests/ModifierSettingsModelTests.swift`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`Tests/NiriMacTests/ModifierSettingsModelTests.swift` を新規作成:
+
+```swift
+import Testing
+import AppKit
+@testable import NiriMac
+
+@Suite("ModifierSettingsModel Tests")
+struct ModifierSettingsModelTests {
+
+    @Test func currentMetaReflectsToggles() {
+        let model = ModifierSettingsModel(
+            meta: [.control, .option],
+            scrollLayout: [.control],
+            scrollFocus: [.control, .option]
+        )
+        #expect(model.currentMeta == [.control, .option])
+        model.metaCommand = true
+        #expect(model.currentMeta == [.control, .option, .command])
+    }
+
+    @Test func hasChangesWhenMetaDiffers() {
+        let model = ModifierSettingsModel(
+            meta: [.control, .option],
+            scrollLayout: [.control],
+            scrollFocus: [.control, .option]
+        )
+        #expect(model.hasChanges == false)
+        model.metaShift = true
+        #expect(model.hasChanges == true)
+    }
+
+    @Test func hasChangesWhenScrollLayoutDiffers() {
+        let model = ModifierSettingsModel(
+            meta: [.control, .option],
+            scrollLayout: [.control],
+            scrollFocus: [.control, .option]
+        )
+        model.layoutOption = true
+        #expect(model.hasChanges == true)
+    }
+
+    @Test func anyEmptyWhenMetaAllUnchecked() {
+        let model = ModifierSettingsModel(
+            meta: [.control],
+            scrollLayout: [.control],
+            scrollFocus: [.control, .option]
+        )
+        model.metaControl = false
+        #expect(model.anyEmpty == true)
+    }
+
+    @Test func metaHasCommandReflectsState() {
+        let model = ModifierSettingsModel(
+            meta: [.control, .option],
+            scrollLayout: [.control],
+            scrollFocus: [.control, .option]
+        )
+        #expect(model.metaHasCommand == false)
+        model.metaCommand = true
+        #expect(model.metaHasCommand == true)
+    }
+}
+```
+
+- [ ] **Step 2: テストがコンパイルエラーで失敗することを確認**
+
+```bash
+swift test --filter ModifierSettingsModelTests 2>&1 | tail -5
+```
+
+Expected: `error: cannot find type 'ModifierSettingsModel'`
+
+- [ ] **Step 3: ModifierSettingsView.swift を作成**
+
+`Sources/NiriMac/App/ModifierSettingsView.swift` を新規作成:
+
+```swift
+import SwiftUI
+import AppKit
+
+final class ModifierSettingsModel: ObservableObject {
+    @Published var metaControl: Bool
+    @Published var metaOption: Bool
+    @Published var metaCommand: Bool
+    @Published var metaShift: Bool
+
+    @Published var layoutControl: Bool
+    @Published var layoutOption: Bool
+    @Published var layoutCommand: Bool
+    @Published var layoutShift: Bool
+
+    @Published var focusControl: Bool
+    @Published var focusOption: Bool
+    @Published var focusCommand: Bool
+    @Published var focusShift: Bool
+
+    private let originalMeta: NSEvent.ModifierFlags
+    private let originalScrollLayout: NSEvent.ModifierFlags
+    private let originalScrollFocus: NSEvent.ModifierFlags
+
+    init(meta: NSEvent.ModifierFlags, scrollLayout: NSEvent.ModifierFlags, scrollFocus: NSEvent.ModifierFlags) {
+        self.originalMeta = meta
+        self.originalScrollLayout = scrollLayout
+        self.originalScrollFocus = scrollFocus
+
+        metaControl = meta.contains(.control)
+        metaOption  = meta.contains(.option)
+        metaCommand = meta.contains(.command)
+        metaShift   = meta.contains(.shift)
+
+        layoutControl = scrollLayout.contains(.control)
+        layoutOption  = scrollLayout.contains(.option)
+        layoutCommand = scrollLayout.contains(.command)
+        layoutShift   = scrollLayout.contains(.shift)
+
+        focusControl = scrollFocus.contains(.control)
+        focusOption  = scrollFocus.contains(.option)
+        focusCommand = scrollFocus.contains(.command)
+        focusShift   = scrollFocus.contains(.shift)
+    }
+
+    var currentMeta: NSEvent.ModifierFlags {
+        flags(metaControl, metaOption, metaCommand, metaShift)
+    }
+
+    var currentScrollLayout: NSEvent.ModifierFlags {
+        flags(layoutControl, layoutOption, layoutCommand, layoutShift)
+    }
+
+    var currentScrollFocus: NSEvent.ModifierFlags {
+        flags(focusControl, focusOption, focusCommand, focusShift)
+    }
+
+    var hasChanges: Bool {
+        currentMeta != originalMeta ||
+        currentScrollLayout != originalScrollLayout ||
+        currentScrollFocus != originalScrollFocus
+    }
+
+    var anyEmpty: Bool {
+        currentMeta.isEmpty || currentScrollLayout.isEmpty || currentScrollFocus.isEmpty
+    }
+
+    var metaHasCommand: Bool { metaCommand }
+
+    private func flags(_ c: Bool, _ o: Bool, _ cmd: Bool, _ s: Bool) -> NSEvent.ModifierFlags {
+        var f: NSEvent.ModifierFlags = []
+        if c   { f.insert(.control) }
+        if o   { f.insert(.option) }
+        if cmd { f.insert(.command) }
+        if s   { f.insert(.shift) }
+        return f
+    }
+}
+
+struct ModifierSettingsView: View {
+    @ObservedObject var model: ModifierSettingsModel
+    var onCancel: () -> Void
+    var onApply: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            GroupBox("Keyboard Meta") {
+                modifierGrid(
+                    control: $model.metaControl,
+                    option:  $model.metaOption,
+                    command: $model.metaCommand,
+                    shift:   $model.metaShift,
+                    isEmpty: model.currentMeta.isEmpty
+                )
+                if model.metaHasCommand {
+                    Label("Command はワークスペース操作と競合します", systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                }
+            }
+
+            GroupBox("Scroll: Layout") {
+                modifierGrid(
+                    control: $model.layoutControl,
+                    option:  $model.layoutOption,
+                    command: $model.layoutCommand,
+                    shift:   $model.layoutShift,
+                    isEmpty: model.currentScrollLayout.isEmpty
+                )
+            }
+
+            GroupBox("Scroll: Focus") {
+                modifierGrid(
+                    control: $model.focusControl,
+                    option:  $model.focusOption,
+                    command: $model.focusCommand,
+                    shift:   $model.focusShift,
+                    isEmpty: model.currentScrollFocus.isEmpty
+                )
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                Button("Restart to Apply") {
+                    ConfigStore.save(
+                        meta: model.currentMeta,
+                        scrollLayout: model.currentScrollLayout,
+                        scrollFocus: model.currentScrollFocus
+                    )
+                    onApply()
+                }
+                .disabled(!model.hasChanges || model.anyEmpty)
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(20)
+        .frame(width: 360)
+    }
+
+    @ViewBuilder
+    private func modifierGrid(
+        control: Binding<Bool>,
+        option:  Binding<Bool>,
+        command: Binding<Bool>,
+        shift:   Binding<Bool>,
+        isEmpty: Bool
+    ) -> some View {
+        Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 4) {
+            GridRow {
+                Toggle("Control (⌃)", isOn: control)
+                Toggle("Option (⌥)",  isOn: option)
+            }
+            GridRow {
+                Toggle("Command (⌘)", isOn: command)
+                Toggle("Shift (⇧)",   isOn: shift)
+            }
+        }
+        .padding(.vertical, 4)
+        if isEmpty {
+            Text("最低1つ選択してください")
+                .font(.caption)
+                .foregroundColor(.red)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: テストがパスすることを確認**
+
+```bash
+swift test --filter ModifierSettingsModelTests 2>&1 | tail -5
+```
+
+Expected: `Test run with 5 tests passed.`
+
+- [ ] **Step 5: 全テストが通ることを確認**
+
+```bash
+swift test 2>&1 | tail -3
+```
+
+Expected: 全テスト pass（93 + 5 = 98 tests）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add Sources/NiriMac/App/ModifierSettingsView.swift Tests/NiriMacTests/ModifierSettingsModelTests.swift
+git commit -m "feat: add ModifierSettingsModel and ModifierSettingsView (SwiftUI)"
+```
+
+---
+
+### Task 2: ModifierSettingsWindowController
+
+**Files:**
+- Create: `Sources/NiriMac/App/ModifierSettingsWindowController.swift`
+
+- [ ] **Step 1: ModifierSettingsWindowController.swift を作成**
+
+`Sources/NiriMac/App/ModifierSettingsWindowController.swift` を新規作成:
+
+```swift
+import AppKit
+import SwiftUI
+
+final class ModifierSettingsWindowController: NSWindowController {
+
+    private static var shared: ModifierSettingsWindowController?
+
+    static func show() {
+        if let existing = shared {
+            existing.window?.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+        let controller = ModifierSettingsWindowController()
+        shared = controller
+        controller.showWindow(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private init() {
+        let stored = ConfigStore.load()
+        let model = ModifierSettingsModel(
+            meta: stored.meta,
+            scrollLayout: stored.scrollLayout,
+            scrollFocus: stored.scrollFocus
+        )
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 100),
+            styleMask: [.titled, .closable, .utilityWindow],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = "Modifier Key Settings"
+        panel.isReleasedWhenClosed = false
+        panel.center()
+
+        super.init(window: panel)
+
+        let view = ModifierSettingsView(
+            model: model,
+            onCancel: { [weak self] in self?.close() },
+            onApply:  { [weak self] in
+                self?.close()
+                ModifierSettingsWindowController.relaunch()
+            }
+        )
+        panel.contentViewController = NSHostingController(rootView: view)
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    override func close() {
+        super.close()
+        Self.shared = nil
+    }
+
+    private static func relaunch() {
+        let bundlePath = Bundle.main.bundlePath
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/sh")
+        task.arguments = ["-c", "sleep 0.5; exec /usr/bin/open \"$1\"", "sh", bundlePath]
+        try? task.run()
+        NSApplication.shared.terminate(nil)
+    }
+}
+```
+
+- [ ] **Step 2: ビルドと全テスト確認**
+
+```bash
+swift build 2>&1 | tail -3 && swift test 2>&1 | tail -3
+```
+
+Expected: `Build complete!` → 全テスト pass
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add Sources/NiriMac/App/ModifierSettingsWindowController.swift
+git commit -m "feat: add ModifierSettingsWindowController (NSPanel singleton)"
+```
+
+---
+
+### Task 3: NiriMacApp — サブメニューを設定ウィンドウに置き換え
+
+**Files:**
+- Modify: `Sources/NiriMac/App/NiriMacApp.swift`
+
+- [ ] **Step 1: 不要なプロパティを削除**
+
+`NiriMacApp` クラスから以下のプロパティを削除する:
+
+```swift
+// 削除対象
+private var pendingMeta: NSEvent.ModifierFlags = [.control, .option]
+private var pendingScrollLayout: NSEvent.ModifierFlags = [.option]
+private var pendingScrollFocus: NSEvent.ModifierFlags = [.control, .option]
+private var restartMenuItem: NSMenuItem?
+```
+
+- [ ] **Step 2: 不要なメソッドを削除**
+
+以下のメソッドを全て削除する:
+- `makeModifierSubmenu(title:current:tag:)` — サブメニュー生成
+- `toggleModifier(_:)` — チェックボックストグル
+- `restartToApply()` — 再起動
+
+- [ ] **Step 3: applicationDidFinishLaunching を簡略化**
+
+`applicationDidFinishLaunching` から pending 値の設定を削除:
+
+```swift
+func applicationDidFinishLaunching(_ notification: Notification) {
+    printDiagnostics()
+    setupStatusBar()
+
+    let stored = ConfigStore.load()
+    var config = LayoutConfig()
+    config.metaModifiers = stored.meta
+    config.scrollLayoutModifiers = stored.scrollLayout
+    config.scrollFocusModifiers = stored.scrollFocus
+    windowManager = WindowManager(config: config)
+    windowManager?.start()
+}
+```
+
+- [ ] **Step 4: setupStatusBar の modifier 関連を置き換える**
+
+`setupStatusBar()` 内の以下の既存ブロックを削除する:
+
+```swift
+// 削除対象（separator + 3つのサブメニュー + restartItem）
+menu.addItem(NSMenuItem.separator())
+menu.addItem(makeModifierSubmenu(title: "Keyboard Meta", current: pendingMeta, tag: 1))
+menu.addItem(makeModifierSubmenu(title: "Scroll: Layout", current: pendingScrollLayout, tag: 2))
+menu.addItem(makeModifierSubmenu(title: "Scroll: Focus", current: pendingScrollFocus, tag: 3))
+
+let restartItem = NSMenuItem(title: "Restart to Apply...", action: #selector(restartToApply), keyEquivalent: "")
+restartItem.target = self
+restartItem.isEnabled = false
+self.restartMenuItem = restartItem
+menu.addItem(restartItem)
+```
+
+代わりに以下を追加（`reLayoutItem` の `menu.addItem(reLayoutItem)` の直後）:
+
+```swift
+menu.addItem(NSMenuItem.separator())
+let settingsItem = NSMenuItem(title: "Modifier Settings...", action: #selector(showModifierSettings), keyEquivalent: "")
+settingsItem.target = self
+menu.addItem(settingsItem)
+```
+
+- [ ] **Step 5: showModifierSettings アクションを追加**
+
+`NiriMacApp` に追加:
+
+```swift
+@objc private func showModifierSettings() {
+    ModifierSettingsWindowController.show()
+}
+```
+
+- [ ] **Step 6: ビルドと全テスト確認**
+
+```bash
+swift build 2>&1 | tail -3 && swift test 2>&1 | tail -3
+```
+
+Expected: `Build complete!` → 全テスト pass
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add Sources/NiriMac/App/NiriMacApp.swift
+git commit -m "feat: replace modifier submenus with Modifier Settings... window"
+```
+
+---
+
+### Task 4: 手動動作確認
+
+- [ ] **Step 1: アプリビルド**
+
+```bash
+bash make-app.sh && open NiriMac.app
+```
+
+- [ ] **Step 2: 設定ウィンドウを開く**
+
+ステータスバー → 「Modifier Settings...」クリック → ウィンドウが開くことを確認
+
+- [ ] **Step 3: 初期状態の確認**
+
+- Keyboard Meta: Control ✓, Option ✓
+- Scroll: Layout: Control ✓
+- Scroll: Focus: Control ✓, Option ✓
+- 「Restart to Apply」はグレーアウト
+
+- [ ] **Step 4: 変更と再起動フロー**
+
+1. Keyboard Meta の Control チェックを外す
+2. 「Restart to Apply」が有効になることを確認
+3. クリック → アプリが再起動する
+4. 再起動後に「Modifier Settings...」を開いて変更が保持されていることを確認
+
+- [ ] **Step 5: シングルトン確認**
+
+「Modifier Settings...」を2回クリック → ウィンドウが2つ開かないことを確認
+
+- [ ] **Step 6: Cancel 確認**
+
+変更後「Cancel」→ 設定が変わっていないことを確認（ConfigStore を読んで元の値のまま）

--- a/docs/superpowers/specs/2026-04-25-meta-key-config-design.md
+++ b/docs/superpowers/specs/2026-04-25-meta-key-config-design.md
@@ -1,0 +1,108 @@
+# Meta Key Configuration — Design Spec
+
+**Date:** 2026-04-25  
+**Status:** Approved
+
+## Overview
+
+キーボードショートカットのベース修飾キー（メタキー）をステータスバーメニューから自由に変更できるようにする。変更は次回起動時に反映される。マウススクロールの修飾キーは対象外。
+
+## Requirements
+
+- ユーザーは Control / Option / Command / Shift を自由に組み合わせてメタキーを設定できる
+- 設定はステータスバーメニューの GUI から変更する
+- 変更は次回起動時に反映される（即時反映なし）
+- メニューから「Restart to Apply」で再起動できる
+- マウススクロールの修飾キー（Ctrl スクロール、Option スクロール）は変更対象外
+
+## Architecture
+
+### Data Model
+
+`LayoutConfig` に `metaModifiers` を追加する：
+
+```swift
+// Engine/LayoutConfig.swift
+var metaModifiers: NSEvent.ModifierFlags = [.control, .option]
+```
+
+### Config Persistence — `ConfigStore.swift`（新規）
+
+`ExclusionStore` と同パターン。`~/.config/niri-mac/config.json` に JSON で保存。
+
+```json
+{ "metaModifiers": ["control", "option"] }
+```
+
+- 起動時に `NiriMacApp` が `ConfigStore.load()` → `LayoutConfig.metaModifiers` にセット
+- メニュー変更時に `ConfigStore.save()` を呼ぶ
+- ファイル不在・パース失敗時はデフォルト `[.control, .option]` を使用
+
+### KeyboardShortcutManager — 動的バインディング生成
+
+現在のハードコード `bindings` 配列を削除し、`start()` 時に `metaModifiers` から動的生成する。
+
+バインディング tier：
+
+| tier | 修飾キー | 代表アクション |
+|------|----------|----------------|
+| meta | `metaModifiers` | フォーカス移動・基本操作 |
+| meta+shift | `metaModifiers ∪ [.shift]` | カラム並べ替え・ウィンドウ並べ替え |
+| meta+cmd | `metaModifiers ∪ [.command]` | ワークスペース切り替え |
+| meta+cmd+shift | `metaModifiers ∪ [.command, .shift]` | ウィンドウをワークスペース移動 |
+
+**競合制約:** `metaModifiers` に `.command` を含む場合、tier1 と tier3 が同一になるため競合する。この場合メニューで警告を表示する（設定自体は保存可能だが、ワークスペース操作が機能しなくなる旨を明示）。
+
+### Status Bar Menu — UI
+
+「Meta Key」サブメニューと「Restart to Apply...」メニュー項目を追加：
+
+```
+Meta Key ▶
+  ✓ Control (⌃)
+  ✓ Option  (⌥)
+    Command (⌘)   ← ⚠️ チェック時「ワークスペース操作と競合します」を表示
+    Shift   (⇧)
+  ──────────────
+  (再起動後に反映)
+
+Restart to Apply...   ← Meta Key 変更後に enabled になる
+```
+
+バリデーション：
+- チェック数 < 2 → 変更を拒否し「最低2つ選択してください」を表示
+- `.command` 追加時 → 「⚠️ ワークスペース操作と競合します」を表示（拒否はしない）
+
+「Restart to Apply...」の動作：
+- Meta Key 未変更時は grayed out
+- クリック → 確認アラート「再起動してメタキーの変更を適用しますか？」→ OK で再起動
+- 再起動実装: `Process` で `open 'NiriMac.app'` をスリープ後に起動し、`NSApplication.shared.terminate(nil)` で終了
+
+## Data Flow
+
+```
+起動時:
+ConfigStore.load() → LayoutConfig.metaModifiers
+LayoutConfig.metaModifiers → KeyboardShortcutManager.buildBindings()
+
+メニュー変更時:
+ユーザーがトグル → バリデーション → ConfigStore.save() → "Restart to Apply..." が enabled に
+
+再起動時:
+"Restart to Apply..." クリック → 確認アラート → NSApplication 再起動
+```
+
+## Files Changed
+
+| ファイル | 変更種別 | 内容 |
+|----------|----------|------|
+| `Engine/LayoutConfig.swift` | 変更 | `metaModifiers: NSEvent.ModifierFlags` 追加 |
+| `Bridge/ConfigStore.swift` | **新規** | JSON 永続化（load/save） |
+| `Bridge/KeyboardShortcutManager.swift` | 変更 | bindings を動的生成に変更 |
+| `App/NiriMacApp.swift` | 変更 | ConfigStore 読み込み・Meta Key メニュー・Restart メニュー追加 |
+
+## Out of Scope
+
+- マウススクロールの修飾キー変更（Ctrl スクロール・Option スクロールはハードコードのまま）
+- 即時反映（再起動が必要）
+- アクションごとの個別キーバインド設定

--- a/docs/superpowers/specs/2026-04-25-meta-key-config-design.md
+++ b/docs/superpowers/specs/2026-04-25-meta-key-config-design.md
@@ -1,29 +1,34 @@
-# Meta Key Configuration — Design Spec
+# Meta Key & Scroll Modifier Configuration — Design Spec
 
 **Date:** 2026-04-25  
 **Status:** Approved
 
 ## Overview
 
-キーボードショートカットのベース修飾キー（メタキー）をステータスバーメニューから自由に変更できるようにする。変更は次回起動時に反映される。マウススクロールの修飾キーは対象外。
+キーボードショートカットのベース修飾キー（Keyboard Meta）と、マウス/トラックパッドスクロールの修飾キー（Scroll: Layout / Scroll: Focus）をステータスバーメニューから自由に変更できるようにする。変更は次回起動時に反映される。
 
 ## Requirements
 
-- ユーザーは Control / Option / Command / Shift を自由に組み合わせてメタキーを設定できる
+- 以下の3つの修飾キーセットを、Control / Option / Command / Shift の自由な組み合わせで設定できる
+  1. **Keyboard Meta**: キーボードショートカットのベース修飾キー（デフォルト: `Ctrl+Opt`）
+  2. **Scroll: Layout**: レイアウトスクロールのトリガー修飾キー（デフォルト: `Option`）
+  3. **Scroll: Focus**: カラムフォーカス移動スクロールのトリガー修飾キー（デフォルト: `Ctrl+Opt`）
 - 設定はステータスバーメニューの GUI から変更する
 - 変更は次回起動時に反映される（即時反映なし）
-- メニューから「Restart to Apply」で再起動できる
-- マウススクロールの修飾キー（Ctrl スクロール、Option スクロール）は変更対象外
+- メニューから「Restart to Apply...」で再起動できる
+- `Ctrl` のみ + 水平スクロールによるレイアウトスクロールは対象外（ハードコードのまま）
 
 ## Architecture
 
 ### Data Model
 
-`LayoutConfig` に `metaModifiers` を追加する：
+`LayoutConfig` に3フィールドを追加する：
 
 ```swift
 // Engine/LayoutConfig.swift
 var metaModifiers: NSEvent.ModifierFlags = [.control, .option]
+var scrollLayoutModifiers: NSEvent.ModifierFlags = [.option]
+var scrollFocusModifiers: NSEvent.ModifierFlags = [.control, .option]
 ```
 
 ### Config Persistence — `ConfigStore.swift`（新規）
@@ -31,12 +36,16 @@ var metaModifiers: NSEvent.ModifierFlags = [.control, .option]
 `ExclusionStore` と同パターン。`~/.config/niri-mac/config.json` に JSON で保存。
 
 ```json
-{ "metaModifiers": ["control", "option"] }
+{
+  "metaModifiers": ["control", "option"],
+  "scrollLayoutModifiers": ["option"],
+  "scrollFocusModifiers": ["control", "option"]
+}
 ```
 
-- 起動時に `NiriMacApp` が `ConfigStore.load()` → `LayoutConfig.metaModifiers` にセット
+- 起動時に `NiriMacApp` が `ConfigStore.load()` → `LayoutConfig` の各フィールドにセット
 - メニュー変更時に `ConfigStore.save()` を呼ぶ
-- ファイル不在・パース失敗時はデフォルト `[.control, .option]` を使用
+- ファイル不在・パース失敗時はデフォルト値を使用
 
 ### KeyboardShortcutManager — 動的バインディング生成
 
@@ -53,37 +62,86 @@ var metaModifiers: NSEvent.ModifierFlags = [.control, .option]
 
 **競合制約:** `metaModifiers` に `.command` を含む場合、tier1 と tier3 が同一になるため競合する。この場合メニューで警告を表示する（設定自体は保存可能だが、ワークスペース操作が機能しなくなる旨を明示）。
 
+### MouseEventManager — 動的 suppress ロジック
+
+現在の suppress ロジック（`Option` のみ固定）を動的化する。
+
+```swift
+// 変更前（ハードコード）
+let suppress = cgFlags.contains(.maskAlternate)
+            && !cgFlags.contains(.maskControl)
+            && !cgFlags.contains(.maskCommand)
+
+// 変更後（動的）
+// scrollLayoutModifiers を外部から注入し、それとフラグが一致する場合に suppress
+let suppress = matchesModifiers(cgFlags, required: scrollLayoutModifiers)
+```
+
+`MouseEventManager` は `scrollLayoutModifiers: NSEvent.ModifierFlags` を保持し、`WindowManager` から渡されるようにする。
+
+### WindowManager — 動的スクロールハンドラ
+
+`handleScroll` 内のハードコード修飾キー判定を `LayoutConfig` の値で置き換える：
+
+```swift
+// 変更前
+if filtered == [.control, .option] { // カラムフォーカス移動
+if filtered == [.option] {           // レイアウトスクロール
+
+// 変更後
+if filtered == config.scrollFocusModifiers {
+if filtered == config.scrollLayoutModifiers {
+```
+
 ### Status Bar Menu — UI
 
-「Meta Key」サブメニューと「Restart to Apply...」メニュー項目を追加：
+3つの修飾キーサブメニューと「Restart to Apply...」を追加：
 
 ```
-Meta Key ▶
+Keyboard Meta ▶
   ✓ Control (⌃)
   ✓ Option  (⌥)
     Command (⌘)   ← ⚠️ チェック時「ワークスペース操作と競合します」を表示
     Shift   (⇧)
-  ──────────────
-  (再起動後に反映)
 
-Restart to Apply...   ← Meta Key 変更後に enabled になる
+Scroll: Layout ▶
+    Control (⌃)
+  ✓ Option  (⌥)
+    Command (⌘)
+    Shift   (⇧)
+
+Scroll: Focus ▶
+  ✓ Control (⌃)
+  ✓ Option  (⌥)
+    Command (⌘)
+    Shift   (⇧)
+
+──────────────
+(再起動後に反映)
+
+Restart to Apply...   ← いずれかの設定変更後に enabled になる
 ```
 
-バリデーション：
-- チェック数 < 2 → 変更を拒否し「最低2つ選択してください」を表示
-- `.command` 追加時 → 「⚠️ ワークスペース操作と競合します」を表示（拒否はしない）
+バリデーション（3つ全てに共通）：
+- チェック数 < 1 → 変更を拒否し「最低1つ選択してください」を表示
+- Keyboard Meta で `.command` を追加した場合 → 「⚠️ ワークスペース操作と競合します」を表示（拒否はしない）
 
 「Restart to Apply...」の動作：
-- Meta Key 未変更時は grayed out
-- クリック → 確認アラート「再起動してメタキーの変更を適用しますか？」→ OK で再起動
+- 全設定未変更時は grayed out
+- クリック → 確認アラート「再起動して設定変更を適用しますか？」→ OK で再起動
 - 再起動実装: `Process` で `open 'NiriMac.app'` をスリープ後に起動し、`NSApplication.shared.terminate(nil)` で終了
 
 ## Data Flow
 
 ```
 起動時:
-ConfigStore.load() → LayoutConfig.metaModifiers
-LayoutConfig.metaModifiers → KeyboardShortcutManager.buildBindings()
+ConfigStore.load()
+  → LayoutConfig.metaModifiers
+  → LayoutConfig.scrollLayoutModifiers
+  → LayoutConfig.scrollFocusModifiers
+  → KeyboardShortcutManager.buildBindings(meta: metaModifiers)
+  → MouseEventManager.scrollLayoutModifiers = scrollLayoutModifiers
+  → WindowManager が scrollFocusModifiers / scrollLayoutModifiers を参照
 
 メニュー変更時:
 ユーザーがトグル → バリデーション → ConfigStore.save() → "Restart to Apply..." が enabled に
@@ -96,13 +154,15 @@ LayoutConfig.metaModifiers → KeyboardShortcutManager.buildBindings()
 
 | ファイル | 変更種別 | 内容 |
 |----------|----------|------|
-| `Engine/LayoutConfig.swift` | 変更 | `metaModifiers: NSEvent.ModifierFlags` 追加 |
+| `Engine/LayoutConfig.swift` | 変更 | `metaModifiers` / `scrollLayoutModifiers` / `scrollFocusModifiers` 追加 |
 | `Bridge/ConfigStore.swift` | **新規** | JSON 永続化（load/save） |
 | `Bridge/KeyboardShortcutManager.swift` | 変更 | bindings を動的生成に変更 |
-| `App/NiriMacApp.swift` | 変更 | ConfigStore 読み込み・Meta Key メニュー・Restart メニュー追加 |
+| `Bridge/MouseEventManager.swift` | 変更 | suppress ロジックを動的化、`scrollLayoutModifiers` を注入 |
+| `Orchestrator/WindowManager.swift` | 変更 | スクロールハンドラの修飾キー判定を動的化 |
+| `App/NiriMacApp.swift` | 変更 | ConfigStore 読み込み・3つのサブメニュー・Restart メニュー追加 |
 
 ## Out of Scope
 
-- マウススクロールの修飾キー変更（Ctrl スクロール・Option スクロールはハードコードのまま）
+- `Ctrl` のみ + 水平スクロールによるレイアウトスクロール（ハードコードのまま）
 - 即時反映（再起動が必要）
 - アクションごとの個別キーバインド設定


### PR DESCRIPTION
## Summary

- キーボードショートカットのベース修飾キー（Keyboard Meta）、スクロールの修飾キー（Scroll: Layout / Scroll: Focus）をステータスバーメニューから自由に変更できるようにした
- 設定は `~/.config/niri-mac/config.json` に永続化され、再起動時に反映される
- ステータスバーに「Restart to Apply...」ボタンを追加

## Changes

- `LayoutConfig`: `metaModifiers` / `scrollLayoutModifiers` / `scrollFocusModifiers` フィールド追加
- `ConfigStore` (新規): JSON 永続化（ExclusionStore と同パターン）
- `KeyboardShortcutManager`: `init(metaModifiers:)` + `buildBindings(meta:)` で動的バインディング生成
- `MouseEventManager`: `scrollLayoutModifiers` プロパティ追加、suppress ロジック動的化
- `WindowManager`: init で config から各 modifier を注入、`handleScroll` の比較を config 参照に変更
- `NiriMacApp`: ConfigStore 読み込み、3つの修飾キーサブメニュー、Restart to Apply... メニュー追加

## Test Plan

- [ ] ステータスバー → Keyboard Meta で Control を外し、Option のみに設定
- [ ] 「Restart to Apply...」をクリック → 確認ダイアログ → 再起動
- [ ] 再起動後、`Option + ←` でカラムフォーカスが動くことを確認
- [ ] `~/.config/niri-mac/config.json` に設定が保存されていることを確認
- [ ] `swift test` — 93 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)