### PR TITLE
fix: remove zombie windows when AX element destroyed notification loses window ID

### DIFF
--- a/Sources/NiriMac/Bridge/AXObserverBridge.swift
+++ b/Sources/NiriMac/Bridge/AXObserverBridge.swift
@@ -10,6 +10,8 @@ final class AXObserverBridge {
     var onApplicationLaunched: ((pid_t) -> Void)?
     var onApplicationTerminated: ((pid_t) -> Void)?
     var onSpaceChanged: (() -> Void)?
+    /// elementWindowMap ミス + 要素破棄済みで windowID が取れなかった場合に発火
+    var onWindowGhostSweepNeeded: (() -> Void)?
 
     private var observers: [pid_t: AXObserver] = [:]
     private var notificationCenter = NotificationCenter.default
@@ -103,10 +105,16 @@ final class AXObserverBridge {
     }
 
     /// 新規ウィンドウの破棄通知をウィンドウ要素に登録する（handleWindowCreated から呼ぶ）
-    func registerWindowDestroyedNotification(for windowElement: AXUIElement, pid: pid_t) {
+    /// knownWindowID を渡すと _AXUIElementGetWindow に依存せずマッピングを確実に保存できる
+    func registerWindowDestroyedNotification(for windowElement: AXUIElement, pid: pid_t, knownWindowID: WindowID? = nil) {
         guard let obs = observers[pid] else { return }
         let selfPtr = Unmanaged.passRetained(self).toOpaque()
-        addDestroyedNotification(obs: obs, windowElement: windowElement, selfPtr: selfPtr)
+        if let windowID = knownWindowID {
+            elementWindowMap[CFHash(windowElement)] = windowID
+            AXObserverAddNotification(obs, windowElement, kAXUIElementDestroyedNotification as CFString, selfPtr)
+        } else {
+            addDestroyedNotification(obs: obs, windowElement: windowElement, selfPtr: selfPtr)
+        }
     }
 
     /// 破棄通知の登録と elementWindowMap への事前保存を行う
@@ -174,6 +182,11 @@ final class AXObserverBridge {
                 if _AXUIElementGetWindow(element, &windowID) == .success {
                     DispatchQueue.main.async { [weak self] in
                         self?.onWindowDestroyed?(windowID)
+                    }
+                } else {
+                    // 要素が破棄済みで ID が取れない場合: ゾンビウィンドウ検出スイープを要求
+                    DispatchQueue.main.async { [weak self] in
+                        self?.onWindowGhostSweepNeeded?()
                     }
                 }
             }

--- a/Sources/NiriMac/Orchestrator/WindowManager.swift
+++ b/Sources/NiriMac/Orchestrator/WindowManager.swift
@@ -365,6 +365,9 @@ final class WindowManager {
         observer.onWindowDestroyed = { [weak self] id in
             self?.handleWindowDestroyed(id)
         }
+        observer.onWindowGhostSweepNeeded = { [weak self] in
+            self?.ghostSweep()
+        }
         observer.onApplicationTerminated = { [weak self] pid in
             self?.handleApplicationTerminated(pid: pid)
         }
@@ -579,7 +582,8 @@ final class WindowManager {
         windowRegistry[window.id] = window
         axBridge.registerElement(window.axElement, for: window.id)
         // ウィンドウ要素に破棄通知を個別登録（appElement への登録では発火しないため）
-        observer.registerWindowDestroyedNotification(for: window.axElement, pid: window.ownerPID)
+        // window.id を直接渡すことで _AXUIElementGetWindow の失敗による登録漏れを防ぐ
+        observer.registerWindowDestroyedNotification(for: window.axElement, pid: window.ownerPID, knownWindowID: window.id)
 
         // screen.frame も Quartz 座標なのでそのまま比較
         guard !screens.isEmpty else { return }
@@ -657,6 +661,18 @@ final class WindowManager {
         // アプリ終了時に該当PIDのウィンドウを全て除去
         let toRemove = windowRegistry.values.filter { $0.ownerPID == pid }.map { $0.id }
         for id in toRemove {
+            handleWindowDestroyed(id)
+        }
+    }
+
+    /// ゾンビウィンドウ検出: elementWindowMap ミスで破棄通知のIDが取れなかった場合に呼ばれる。
+    /// CGWindowListCopyWindowInfo で実在するウィンドウIDと照合し、消えたIDを除去する。
+    private func ghostSweep() {
+        guard let list = CGWindowListCopyWindowInfo([.excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] else { return }
+        let liveIDs = Set(list.compactMap { $0[kCGWindowNumber as String] as? CGWindowID })
+        let deadIDs = windowRegistry.keys.filter { !liveIDs.contains($0) }
+        for id in deadIDs {
+            niriLog("[ghost-sweep] zombie window removed: \(id)")
             handleWindowDestroyed(id)
         }
     }


### PR DESCRIPTION
## Summary

- `_AXUIElementGetWindow` が登録時に失敗すると `elementWindowMap` にエントリが保存されず、ウィンドウ破棄通知発火時にIDが取得できないためゾンビウィンドウが発生していた
- `registerWindowDestroyedNotification` に `knownWindowID` 引数を追加し、`handleWindowCreated` 時点で既知の `window.id` を直接渡すことで登録漏れを解消
- 両方のルックアップが失敗した場合に `onWindowGhostSweepNeeded` を発火し、`ghostSweep()` が `CGWindowListCopyWindowInfo` でレジストリ内のゾンビを検出・除去する

## Root cause

`AXObserverBridge.addDestroyedNotification` にて `_AXUIElementGetWindow` が失敗した場合（Electron/JVM 系アプリで発生しやすいレースコンディション）、`elementWindowMap` にマッピングが保存されない。ウィンドウ閉鎖時に通知は発火するが、要素はすでに破棄済みで ID が取れず `onWindowDestroyed` が呼ばれないまま、ウィンドウが `windowRegistry` と `screens` に残り続ける。

## Test plan

- [ ] 通常のアプリ（Safari, Finder 等）でウィンドウを開いて閉じ、レイアウトから消えることを確認
- [ ] Electron 系アプリ（VS Code 等）でウィンドウを閉じ、ゾンビが残らないことを確認
- [ ] `/tmp/niri-mac.log` で `[ghost-sweep] zombie window removed` が出ないことを確認（出た場合はフォールバックが機能していることを意味する）

🤖 Generated with [Claude Code](https://claude.com/claude-code)