### PR TITLE
feat: float window — 常に最前面固定表示機能

### DIFF
--- a/Sources/NiriMac/App/NiriMacApp.swift
+++ b/Sources/NiriMac/App/NiriMacApp.swift
@@ -7,6 +7,7 @@ final class NiriMacApp: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var pinMenuItem: NSMenuItem?
     /// menuWillOpen 時点のカラムインデックスを保持（クリック後のフォーカス変化対策）
     private var pinnedTargetColumnIndex: Int?
+    private var floatMenuItem: NSMenuItem?
     private var focusBorderMenuItem: NSMenuItem?
     private var focusDimMenuItem: NSMenuItem?
     private var autoFitMenuItem: NSMenuItem?
@@ -62,11 +63,16 @@ final class NiriMacApp: NSObject, NSApplicationDelegate, NSMenuDelegate {
         pinItem.target = self
         self.pinMenuItem = pinItem
 
+        let floatItem = NSMenuItem(title: "Float Window", action: #selector(toggleFloat), keyEquivalent: "")
+        floatItem.target = self
+        self.floatMenuItem = floatItem
+
         let menu = NSMenu()
         menu.delegate = self
         menu.addItem(NSMenuItem(title: "niri-mac", action: nil, keyEquivalent: ""))
         menu.addItem(NSMenuItem.separator())
         menu.addItem(pinItem)
+        menu.addItem(floatItem)
         menu.addItem(NSMenuItem.separator())
 
         let excludedAppsItem = NSMenuItem(title: "Excluded Apps", action: nil, keyEquivalent: "")
@@ -114,6 +120,9 @@ final class NiriMacApp: NSObject, NSApplicationDelegate, NSMenuDelegate {
         pinnedTargetColumnIndex = windowManager?.activeColumnIndex
         let isPinned = windowManager?.activeColumnIsPinned ?? false
         pinMenuItem?.title = isPinned ? "Unpin Column" : "Pin Column"
+        let isFloat = windowManager?.frontWindowIsFloat ?? false
+        floatMenuItem?.title = isFloat ? "Unfloat Window" : "Float Window"
+        floatMenuItem?.state = isFloat ? .on : .off
         autoFitMenuItem?.state = windowManager?.autoFitEnabled == true ? .on : .off
         focusBorderMenuItem?.state = windowManager?.focusBorderEnabled == true ? .on : .off
         focusDimMenuItem?.state = windowManager?.focusDimEnabled == true ? .on : .off
@@ -154,6 +163,10 @@ final class NiriMacApp: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     @objc private func togglePin() {
         windowManager?.handleAction(.togglePin, forColumnIndex: pinnedTargetColumnIndex)
+    }
+
+    @objc private func toggleFloat() {
+        windowManager?.toggleFloatFromMenu()
     }
 
     @objc private func toggleAutoFit() {

--- a/Sources/NiriMac/Bridge/KeyboardShortcutManager.swift
+++ b/Sources/NiriMac/Bridge/KeyboardShortcutManager.swift
@@ -31,6 +31,7 @@ final class KeyboardShortcutManager {
         case moveWindowUpInColumn, moveWindowDownInColumn
         case growWindowHeight, shrinkWindowHeight
         case toggleAutoFit
+        case toggleFloat
         case quit
         case reLayout
     }
@@ -96,6 +97,8 @@ final class KeyboardShortcutManager {
             Binding(modifiers: meta,         keyCode: 24,  action: .growWindowHeight),
             // Auto-Fit
             Binding(modifiers: meta,         keyCode: 0,   action: .toggleAutoFit),
+            // Float Window (Ctrl+Opt+F)
+            Binding(modifiers: meta,         keyCode: 3,   action: .toggleFloat),
             // 終了
             Binding(modifiers: meta,         keyCode: 12,  action: .quit),
             // Re-layout

--- a/Sources/NiriMac/Bridge/PrivateAPI.swift
+++ b/Sources/NiriMac/Bridge/PrivateAPI.swift
@@ -33,3 +33,7 @@ func CGSCopyManagedDisplaySpaces(_ cid: UInt32) -> CFArray
 
 let kCGSAllSpacesMask: UInt32 = 0x0F
 let kCGSCurrentSpaceMask: UInt32 = 0x01
+
+/// ウィンドウのレベル（常に最前面等）を設定する
+@_silgen_name("CGSSetWindowLevel")
+func CGSSetWindowLevel(_ cid: UInt32, _ wid: CGWindowID, _ level: Int32) -> CGError

--- a/Sources/NiriMac/Orchestrator/WindowManager.swift
+++ b/Sources/NiriMac/Orchestrator/WindowManager.swift
@@ -44,6 +44,9 @@ final class WindowManager {
     /// park済みウィンドウのキャッシュ（毎フレームのSpaceAPI呼び出しを防ぐ）
     private var parkedWindowIDs: Set<WindowID> = []
 
+    /// float状態のウィンドウ（タイリング除外・常に最前面）
+    private var floatWindowIDs: Set<WindowID> = []
+
     /// 前回のfrontmostApplication PID（setWindowFrame由来の誤発火を防ぐ）
     private var lastFrontmostPID: pid_t = 0
 
@@ -632,6 +635,7 @@ final class WindowManager {
         windowRegistry.removeValue(forKey: id)
         axBridge.removeElement(for: id)
         parkedWindowIDs.remove(id)
+        floatWindowIDs.remove(id)
 
         // ドラッグ状態をクリア（③）
         if mouseDownWindowID == id { mouseDownWindowID = nil }
@@ -763,6 +767,71 @@ final class WindowManager {
         config.autoFitEnabled.toggle()
         niriLog("[action] toggleAutoFit → \(config.autoFitEnabled)")
         needsLayout = true
+    }
+
+    // MARK: - Float Window
+
+    /// メニューバー用: 現在最前面のウィンドウが float 状態かを返す
+    var frontWindowIsFloat: Bool {
+        if let (fwID, _) = frontmostWindowIDAndFrame() {
+            return floatWindowIDs.contains(fwID)
+        }
+        let idx = activeScreenIndex()
+        guard idx < screens.count,
+              let windowID = screens[idx].activeWorkspace.activeWindowID else { return false }
+        return floatWindowIDs.contains(windowID)
+    }
+
+    /// メニューバー用: 最前面ウィンドウの float を切り替える
+    func toggleFloatFromMenu() {
+        let screenIdx = activeScreenIndex()
+        guard screenIdx < screens.count else { return }
+        toggleFloatWindow(screenIdx: screenIdx)
+    }
+
+    private func toggleFloatWindow(screenIdx: Int) {
+        // float中のウィンドウはlayoutから除外済みなので frontmostWindowIDAndFrame で判定
+        let targetID: WindowID?
+        if let (fwID, _) = frontmostWindowIDAndFrame(), floatWindowIDs.contains(fwID) {
+            targetID = fwID
+        } else {
+            targetID = screens[screenIdx].activeWorkspace.activeWindowID
+        }
+        guard let windowID = targetID else { return }
+
+        if floatWindowIDs.contains(windowID) {
+            // Float OFF: タイリングに復帰
+            floatWindowIDs.remove(windowID)
+            setWindowLevel(windowID, level: Int32(NSWindow.Level.normal.rawValue))
+            if windowRegistry[windowID] != nil {
+                let screenWidth = screens[screenIdx].frame.width
+                let colWidth = (windowRegistry[windowID]!.frame.width > 0)
+                    ? windowRegistry[windowID]!.frame.width
+                    : config.defaultColumnWidth(for: screenWidth)
+                let col = Column(windows: [windowID], width: colWidth)
+                screens[screenIdx].activeWorkspace.addColumn(col)
+                screens[screenIdx].activeWorkspace.recenterViewOffset(gap: config.gapWidth)
+            }
+            niriLog("[float] float OFF: win=\(windowID)")
+        } else {
+            // Float ON: タイリングから除外してウィンドウレベルを浮かせる
+            floatWindowIDs.insert(windowID)
+            parkedWindowIDs.remove(windowID)
+            setWindowLevel(windowID, level: Int32(NSWindow.Level.floating.rawValue))
+            for i in screens.indices {
+                for j in screens[i].workspaces.indices {
+                    screens[i].workspaces[j].removeWindow(windowID)
+                }
+            }
+            screens[screenIdx].activeWorkspace.recenterViewOffset(gap: config.gapWidth)
+            niriLog("[float] float ON: win=\(windowID)")
+        }
+        needsLayout = true
+    }
+
+    private func setWindowLevel(_ windowID: WindowID, level: Int32) {
+        let cid = CGSMainConnectionID()
+        _ = CGSSetWindowLevel(cid, windowID, level)
     }
 
     func handleAction(_ action: KeyboardShortcutManager.Action) {
@@ -926,6 +995,10 @@ final class WindowManager {
 
         case .toggleAutoFit:
             toggleAutoFit()
+
+        case .toggleFloat:
+            toggleFloatWindow(screenIdx: screenIdx)
+            return
 
         case .quit:
             stop()


### PR DESCRIPTION
## Summary

Closes #22

- `CGSSetWindowLevel` private API でウィンドウを常に最前面に固定する Float Window 機能を追加

## Changes

- **`PrivateAPI.swift`**: `CGSSetWindowLevel` 宣言追加
- **`KeyboardShortcutManager.swift`**: `toggleFloat` アクション追加 (`Ctrl+Opt+F`)
- **`WindowManager.swift`**: `floatWindowIDs` による float 状態管理・`toggleFloatWindow` 実装
- **`NiriMacApp.swift`**: "Float Window / Unfloat Window" ステータスバーメニュー追加

## Behavior

| 操作 | 結果 |
|---|---|
| `Ctrl+Opt+F` | アクティブウィンドウのfloat ON/OFF |
| ステータスバーメニュー | "Float Window" / "Unfloat Window" でトグル |

- Float ON: タイリングレイアウトから除外 + `kCGFloatingWindowLevel` で最前面固定
- Float OFF: タイリングに新規カラムとして復帰 + ウィンドウレベルをノーマルにリセット

## Test plan

- [ ] `Ctrl+Opt+F` でウィンドウが最前面固定されることを確認
- [ ] 再度 `Ctrl+Opt+F` でタイリングに復帰することを確認
- [ ] ステータスバーメニューの "Float Window / Unfloat Window" 表示が正しく切り替わることを確認
- [ ] float中のウィンドウを閉じても問題ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)